### PR TITLE
Add artists from spotify to show cards

### DIFF
--- a/app/api/artists/search/route.ts
+++ b/app/api/artists/search/route.ts
@@ -3,25 +3,30 @@ import { searchArtists, isSpotifyConfigured } from '@/lib/spotify'
 
 export async function GET(request: NextRequest) {
   try {
-    if (!isSpotifyConfigured) {
-      return NextResponse.json({ 
-        error: 'Spotify API not configured',
-        message: 'Please add SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET to your environment variables to use this feature.'
-      }, { status: 503 })
-    }
-
     const { searchParams } = new URL(request.url)
     const query = searchParams.get('q')
-    const limit = parseInt(searchParams.get('limit') || '20')
 
     if (!query) {
       return NextResponse.json({ error: 'Query parameter is required' }, { status: 400 })
     }
 
-    const artists = await searchArtists(query, limit)
-    return NextResponse.json(artists)
+    // Check if Spotify is configured
+    if (!isSpotifyConfigured) {
+      return NextResponse.json({ 
+        error: 'Spotify API not configured. Please add SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET to your environment variables.' 
+      }, { status: 500 })
+    }
+
+    // Search for artists using the existing function
+    const artists = await searchArtists(query, 10)
+    
+    return NextResponse.json({
+      artists: artists || []
+    })
   } catch (error) {
-    console.error('Error in GET /api/artists/search:', error)
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    console.error('Search error:', error)
+    return NextResponse.json({ 
+      error: error instanceof Error ? error.message : 'Internal server error' 
+    }, { status: 500 })
   }
 }

--- a/app/api/recap/route.ts
+++ b/app/api/recap/route.ts
@@ -70,6 +70,31 @@ export interface RecapData {
       count: number
     } | null
     
+    // Personal artist stats
+    personalTopArtists: Array<{
+      artist: string
+      count: number
+      position: string
+      image_url?: string
+    }>
+    personalTopHeadliners: Array<{
+      artist: string
+      count: number
+      image_url?: string
+    }>
+    personalTopSupportActs: Array<{
+      artist: string
+      count: number
+      image_url?: string
+    }>
+    personalMostSeenArtist: {
+      artist: string
+      count: number
+      image_url?: string
+    } | null
+    personalUniqueArtists: number
+    personalArtistDiversity: number // ratio of unique artists to total shows
+    
     // Group stats
     totalShows: number
     groupBusiestMonth: {
@@ -102,6 +127,35 @@ export interface RecapData {
     biggestStreak: {
       user: string
       streak: number
+    } | null
+    
+    // Group artist stats
+    groupTopArtists: Array<{
+      artist: string
+      count: number
+      position: string
+      image_url?: string
+    }>
+    groupTopHeadliners: Array<{
+      artist: string
+      count: number
+      image_url?: string
+    }>
+    groupTopSupportActs: Array<{
+      artist: string
+      count: number
+      image_url?: string
+    }>
+    groupMostSeenArtist: {
+      artist: string
+      count: number
+      image_url?: string
+    } | null
+    groupUniqueArtists: number
+    groupArtistDiversity: number
+    mostDiverseUser: {
+      name: string
+      diversity: number
     } | null
   }
 }

--- a/app/api/shows/[id]/route.ts
+++ b/app/api/shows/[id]/route.ts
@@ -56,7 +56,7 @@ export async function PUT(
 ) {
   try {
     const { id } = await params
-    const { title, date_local, time_local, city, venue, ticket_url, spotify_url, apple_music_url, google_photos_url, poster_url, notes } = await request.json()
+    const { title, date_local, time_local, city, venue, ticket_url, google_photos_url, poster_url, notes, show_artists } = await request.json()
 
     if (!id) {
       return NextResponse.json(
@@ -96,15 +96,6 @@ export async function PUT(
       return NextResponse.json({ error: ticketUrlValidation.error }, { status: 400 })
     }
 
-    const spotifyUrlValidation = validateUrl(spotify_url || '')
-    if (!spotifyUrlValidation.isValid) {
-      return NextResponse.json({ error: spotifyUrlValidation.error }, { status: 400 })
-    }
-
-    const appleMusicUrlValidation = validateUrl(apple_music_url || '')
-    if (!appleMusicUrlValidation.isValid) {
-      return NextResponse.json({ error: appleMusicUrlValidation.error }, { status: 400 })
-    }
 
     const googlePhotosUrlValidation = validateUrl(google_photos_url || '')
     if (!googlePhotosUrlValidation.isValid) {
@@ -134,11 +125,10 @@ export async function PUT(
         city: cityValidation.sanitizedValue,
         venue: venueValidation.sanitizedValue,
         ticket_url: ticketUrlValidation.sanitizedValue || null,
-        spotify_url: spotifyUrlValidation.sanitizedValue || null,
-        apple_music_url: appleMusicUrlValidation.sanitizedValue || null,
         google_photos_url: googlePhotosUrlValidation.sanitizedValue || null,
         poster_url: posterUrlValidation.sanitizedValue || null,
-        notes: notesValidation.sanitizedValue || null
+        notes: notesValidation.sanitizedValue || null,
+        show_artists: show_artists || []
       })
       .eq('id', id)
       .select()

--- a/app/api/shows/route.ts
+++ b/app/api/shows/route.ts
@@ -15,7 +15,7 @@ import {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { title, date_local, time_local, city, venue, ticket_url, spotify_url, apple_music_url, google_photos_url, poster_url, notes } = body
+    const { title, date_local, time_local, city, venue, ticket_url, google_photos_url, poster_url, notes, show_artists } = body
 
     // Validate and sanitize all inputs
     const titleValidation = validateTitle(title)
@@ -48,15 +48,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ticketUrlValidation.error }, { status: 400 })
     }
 
-    const spotifyUrlValidation = validateUrl(spotify_url || '')
-    if (!spotifyUrlValidation.isValid) {
-      return NextResponse.json({ error: spotifyUrlValidation.error }, { status: 400 })
-    }
-
-    const appleMusicUrlValidation = validateUrl(apple_music_url || '')
-    if (!appleMusicUrlValidation.isValid) {
-      return NextResponse.json({ error: appleMusicUrlValidation.error }, { status: 400 })
-    }
 
     const googlePhotosUrlValidation = validateUrl(google_photos_url || '')
     if (!googlePhotosUrlValidation.isValid) {
@@ -87,11 +78,10 @@ export async function POST(request: NextRequest) {
           city: cityValidation.sanitizedValue,
           venue: venueValidation.sanitizedValue,
           ticket_url: ticketUrlValidation.sanitizedValue || null,
-          spotify_url: spotifyUrlValidation.sanitizedValue || null,
-          apple_music_url: appleMusicUrlValidation.sanitizedValue || null,
           google_photos_url: googlePhotosUrlValidation.sanitizedValue || null,
           poster_url: posterUrlValidation.sanitizedValue || null,
-          notes: notesValidation.sanitizedValue || null
+          notes: notesValidation.sanitizedValue || null,
+          show_artists: show_artists || []
         }
       ])
       .select()

--- a/app/recap/page.tsx
+++ b/app/recap/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectOption, SelectTrigger } from '@/components/ui/select'
@@ -481,9 +482,6 @@ export default function RecapPage() {
                         <div className="text-xs text-muted-foreground mt-1">
                           Unique artists seen
                         </div>
-                        <div className="text-xs text-muted-foreground">
-                          {(recapData.stats.personalArtistDiversity * 100).toFixed(1)}% diversity
-                        </div>
                       </div>
                       
                       <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
@@ -513,9 +511,11 @@ export default function RecapPage() {
                                 {index + 1}
                               </div>
                               {artist.image_url && (
-                                <img 
+                                <Image 
                                   src={artist.image_url} 
                                   alt={artist.artist}
+                                  width={32}
+                                  height={32}
                                   className="w-8 h-8 rounded-full object-cover"
                                 />
                               )}
@@ -644,19 +644,6 @@ export default function RecapPage() {
                         </div>
                       </div>
                       
-                      {/* Group Artist Diversity Stats */}
-                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
-                        <div className="text-sm text-muted-foreground">Group Artist Diversity</div>
-                        <div className="text-2xl font-bold text-primary">
-                          {recapData.stats.groupUniqueArtists}
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1">
-                          Unique artists seen
-                        </div>
-                        <div className="text-xs text-muted-foreground">
-                          {(recapData.stats.groupArtistDiversity * 100).toFixed(1)}% diversity
-                        </div>
-                      </div>
                       
                       <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
                         <div className="text-sm text-muted-foreground">Group Most Seen Artist</div>
@@ -668,15 +655,6 @@ export default function RecapPage() {
                         </div>
                       </div>
                       
-                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
-                        <div className="text-sm text-muted-foreground">Most Diverse User</div>
-                        <div className="text-lg font-bold text-primary">
-                          {recapData.stats.mostDiverseUser?.name ? formatNameForDisplay(recapData.stats.mostDiverseUser.name) : 'N/A'}
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1">
-                          {(recapData.stats.mostDiverseUser?.diversity || 0 * 100).toFixed(1)}% diversity
-                        </div>
-                      </div>
                     </div>
                   </div>
 
@@ -695,9 +673,11 @@ export default function RecapPage() {
                                 {index + 1}
                               </div>
                               {artist.image_url && (
-                                <img 
+                                <Image 
                                   src={artist.image_url} 
                                   alt={artist.artist}
+                                  width={32}
+                                  height={32}
                                   className="w-8 h-8 rounded-full object-cover"
                                 />
                               )}

--- a/app/recap/page.tsx
+++ b/app/recap/page.tsx
@@ -471,7 +471,67 @@ export default function RecapPage() {
                           </div>
                         )}
                       </div>
+                      
+                      {/* Artist Diversity Stats */}
+                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
+                        <div className="text-sm text-muted-foreground">Artist Diversity</div>
+                        <div className="text-2xl font-bold text-primary">
+                          {recapData.stats.personalUniqueArtists}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          Unique artists seen
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {(recapData.stats.personalArtistDiversity * 100).toFixed(1)}% diversity
+                        </div>
+                      </div>
+                      
+                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
+                        <div className="text-sm text-muted-foreground">Most Seen Artist</div>
+                        <div className="text-lg font-bold text-primary truncate">
+                          {recapData.stats.personalMostSeenArtist?.artist || 'N/A'}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          {recapData.stats.personalMostSeenArtist?.count || 0} times
+                        </div>
+                      </div>
                     </div>
+                  </div>
+
+                  {/* Personal Artist Stats */}
+                  <div className="space-y-4">
+                    <h4 className="font-semibold text-lg text-foreground">Your Artist Stats</h4>
+                    
+                    {/* Top Artists */}
+                    {recapData.stats.personalTopArtists.length > 0 && (
+                      <div className="space-y-3">
+                        <h5 className="font-medium text-foreground">Your Top Artists</h5>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                          {recapData.stats.personalTopArtists.slice(0, 8).map((artist, index) => (
+                            <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                              <div className="text-sm font-medium text-muted-foreground w-6">
+                                {index + 1}
+                              </div>
+                              {artist.image_url && (
+                                <img 
+                                  src={artist.image_url} 
+                                  alt={artist.artist}
+                                  className="w-8 h-8 rounded-full object-cover"
+                                />
+                              )}
+                              <div className="flex-1 min-w-0">
+                                <div className="font-medium text-foreground truncate">
+                                  {artist.artist}
+                                </div>
+                                <div className="text-xs text-muted-foreground">
+                                  {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
 
                   {/* Group Stats */}
@@ -583,7 +643,77 @@ export default function RecapPage() {
                           {recapData.stats.biggestStreak?.streak || 0} months in a row
                         </div>
                       </div>
+                      
+                      {/* Group Artist Diversity Stats */}
+                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
+                        <div className="text-sm text-muted-foreground">Group Artist Diversity</div>
+                        <div className="text-2xl font-bold text-primary">
+                          {recapData.stats.groupUniqueArtists}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          Unique artists seen
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {(recapData.stats.groupArtistDiversity * 100).toFixed(1)}% diversity
+                        </div>
+                      </div>
+                      
+                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
+                        <div className="text-sm text-muted-foreground">Group Most Seen Artist</div>
+                        <div className="text-lg font-bold text-primary truncate">
+                          {recapData.stats.groupMostSeenArtist?.artist || 'N/A'}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          {recapData.stats.groupMostSeenArtist?.count || 0} times
+                        </div>
+                      </div>
+                      
+                      <div className="bg-primary/5 border border-primary/20 rounded-lg p-4">
+                        <div className="text-sm text-muted-foreground">Most Diverse User</div>
+                        <div className="text-lg font-bold text-primary">
+                          {recapData.stats.mostDiverseUser?.name ? formatNameForDisplay(recapData.stats.mostDiverseUser.name) : 'N/A'}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-1">
+                          {(recapData.stats.mostDiverseUser?.diversity || 0 * 100).toFixed(1)}% diversity
+                        </div>
+                      </div>
                     </div>
+                  </div>
+
+                  {/* Group Artist Stats */}
+                  <div className="space-y-4">
+                    <h4 className="font-semibold text-lg text-foreground">Group Artist Stats</h4>
+                    
+                    {/* Group Top Artists */}
+                    {recapData.stats.groupTopArtists.length > 0 && (
+                      <div className="space-y-3">
+                        <h5 className="font-medium text-foreground">Group Top Artists</h5>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                          {recapData.stats.groupTopArtists.slice(0, 8).map((artist, index) => (
+                            <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                              <div className="text-sm font-medium text-muted-foreground w-6">
+                                {index + 1}
+                              </div>
+                              {artist.image_url && (
+                                <img 
+                                  src={artist.image_url} 
+                                  alt={artist.artist}
+                                  className="w-8 h-8 rounded-full object-cover"
+                                />
+                              )}
+                              <div className="flex-1 min-w-0">
+                                <div className="font-medium text-foreground truncate">
+                                  {artist.artist}
+                                </div>
+                                <div className="text-xs text-muted-foreground">
+                                  {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                </div>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </CardContent>
               </Card>

--- a/components/AddShowModal.tsx
+++ b/components/AddShowModal.tsx
@@ -15,6 +15,8 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectTrigger, SelectContent, SelectOption } from '@/components/ui/select'
+import { ShowArtist } from '@/lib/types'
+import { ShowArtistsManager } from '@/components/ShowArtistsManager'
 
 interface AddShowModalProps {
   open: boolean
@@ -30,11 +32,10 @@ export function AddShowModal({ open, onOpenChange, onShowAdded }: AddShowModalPr
     city: 'Boston',
     venue: '',
     ticket_url: '',
-    spotify_url: '',
-    apple_music_url: '',
     poster_url: '',
     notes: ''
   })
+  const [showArtists, setShowArtists] = useState<ShowArtist[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [uploading, setUploading] = useState(false)
@@ -115,7 +116,7 @@ export function AddShowModal({ open, onOpenChange, onShowAdded }: AddShowModalPr
       const response = await fetch('/api/shows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...formData, poster_url: posterUrl })
+        body: JSON.stringify({ ...formData, poster_url: posterUrl, show_artists: showArtists })
       })
 
       if (!response.ok) {
@@ -131,11 +132,10 @@ export function AddShowModal({ open, onOpenChange, onShowAdded }: AddShowModalPr
         city: 'Boston',
         venue: '',
         ticket_url: '',
-        spotify_url: '',
-        apple_music_url: '',
         poster_url: '',
         notes: ''
       })
+      setShowArtists([])
       setSelectedFile(null)
       setPreviewUrl(null)
       onOpenChange(false)
@@ -331,6 +331,12 @@ export function AddShowModal({ open, onOpenChange, onShowAdded }: AddShowModalPr
                 required
               />
             </div>
+
+            {/* Show Artists Management */}
+            <ShowArtistsManager
+              showArtists={showArtists}
+              onArtistsChange={setShowArtists}
+            />
             
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground">Ticket URL</label>
@@ -344,29 +350,6 @@ export function AddShowModal({ open, onOpenChange, onShowAdded }: AddShowModalPr
               />
             </div>
             
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Spotify URL</label>
-              <Input
-                type="url"
-                value={formData.spotify_url}
-                onChange={(e) => handleChange('spotify_url', e.target.value)}
-                placeholder="https://open.spotify.com/..."
-                className="w-full h-10 text-sm"
-                style={{ fontSize: '16px' }}
-              />
-            </div>
-            
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Apple Music URL</label>
-              <Input
-                type="url"
-                value={formData.apple_music_url}
-                onChange={(e) => handleChange('apple_music_url', e.target.value)}
-                placeholder="https://music.apple.com/..."
-                className="w-full h-10 text-sm"
-                style={{ fontSize: '16px' }}
-              />
-            </div>
             
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground">Poster Image</label>

--- a/components/EditShowModal.tsx
+++ b/components/EditShowModal.tsx
@@ -6,8 +6,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectTrigger, SelectContent, SelectOption } from '@/components/ui/select'
-import { Show } from '@/lib/types'
+import { Show, ShowArtist } from '@/lib/types'
 import { formatInTimeZone } from 'date-fns-tz'
+import { ShowArtistsManager } from '@/components/ShowArtistsManager'
 
 interface EditShowModalProps {
   open: boolean
@@ -25,12 +26,11 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
     city: 'Boston',
     venue: '',
     ticket_url: '',
-    spotify_url: '',
-    apple_music_url: '',
     google_photos_url: '',
     poster_url: '',
     notes: ''
   })
+  const [showArtists, setShowArtists] = useState<ShowArtist[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [uploading, setUploading] = useState(false)
@@ -49,12 +49,11 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
         city: show.city,
         venue: show.venue,
         ticket_url: show.ticket_url || '',
-        spotify_url: show.spotify_url || '',
-        apple_music_url: show.apple_music_url || '',
         google_photos_url: show.google_photos_url || '',
         poster_url: show.poster_url || '',
         notes: show.notes || ''
       })
+      setShowArtists(show.show_artists || [])
       setSelectedFile(null)
       setPreviewUrl(show.poster_url || null)
     }
@@ -99,7 +98,7 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
       const response = await fetch(`/api/shows/${show.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...formData, poster_url: posterUrl })
+        body: JSON.stringify({ ...formData, poster_url: posterUrl, show_artists: showArtists })
       })
 
       if (!response.ok) {
@@ -301,6 +300,12 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
                 required
               />
             </div>
+
+            {/* Show Artists Management */}
+            <ShowArtistsManager
+              showArtists={showArtists}
+              onArtistsChange={setShowArtists}
+            />
             
             {!isPast && (
               <div className="space-y-2">
@@ -330,29 +335,6 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
               </div>
             )}
             
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Spotify URL</label>
-              <Input
-                type="url"
-                value={formData.spotify_url}
-                onChange={(e) => handleChange('spotify_url', e.target.value)}
-                placeholder="https://open.spotify.com/..."
-                className="w-full h-10 text-sm"
-                style={{ fontSize: '16px' }}
-              />
-            </div>
-            
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-foreground">Apple Music URL</label>
-              <Input
-                type="url"
-                value={formData.apple_music_url}
-                onChange={(e) => handleChange('apple_music_url', e.target.value)}
-                placeholder="https://music.apple.com/..."
-                className="w-full h-10 text-sm"
-                style={{ fontSize: '16px' }}
-              />
-            </div>
             
             {!isPast && (
               <div className="space-y-2">
@@ -436,7 +418,7 @@ export function EditShowModal({ open, onOpenChange, show, onShowUpdated, isPast 
                 rows={3}
               />
             </div>
-            
+
             {error && (
               <p className="text-sm text-red-600">{error}</p>
             )}

--- a/components/ShowArtistsManager.tsx
+++ b/components/ShowArtistsManager.tsx
@@ -1,0 +1,236 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { ShowArtist } from '@/lib/types'
+import { Plus, Trash2, Search } from 'lucide-react'
+
+interface ShowArtistsManagerProps {
+  showArtists: ShowArtist[]
+  onArtistsChange: (artists: ShowArtist[]) => void
+}
+
+interface SpotifySearchResult {
+  id: string
+  name: string
+  external_urls: {
+    spotify: string
+  }
+  images: Array<{
+    url: string
+    height: number
+    width: number
+  }>
+}
+
+export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtistsManagerProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<SpotifySearchResult[]>([])
+  const [searching, setSearching] = useState(false)
+  const [showSearch, setShowSearch] = useState(false)
+
+  const searchSpotify = async (query: string) => {
+    if (!query.trim()) {
+      setSearchResults([])
+      return
+    }
+
+    setSearching(true)
+    try {
+      const response = await fetch(`/api/artists/search?q=${encodeURIComponent(query)}`)
+      if (response.ok) {
+        const data = await response.json()
+        setSearchResults(data.artists || [])
+      } else {
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+        console.error('Search failed:', errorData.error || response.statusText)
+        setSearchResults([])
+        // You could show a toast notification here if you have a toast system
+        alert(`Search failed: ${errorData.error || response.statusText}`)
+      }
+    } catch (error) {
+      console.error('Search error:', error)
+      setSearchResults([])
+      alert('Search failed: Network error. Please check your connection.')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const handleSearch = () => {
+    searchSpotify(searchQuery)
+  }
+
+  const addArtist = (spotifyArtist: SpotifySearchResult) => {
+    // First artist is headliner, subsequent artists are support by default
+    const isFirstArtist = showArtists.length === 0
+    const newArtist: ShowArtist = {
+      artist: spotifyArtist.name,
+      position: isFirstArtist ? 'Headliner' : 'Support',
+      image_url: spotifyArtist.images[0]?.url || '',
+      spotify_id: spotifyArtist.id,
+      spotify_url: spotifyArtist.external_urls.spotify
+    }
+
+    onArtistsChange([...showArtists, newArtist])
+    setSearchQuery('')
+    setSearchResults([])
+    setShowSearch(false)
+  }
+
+  const removeArtist = (index: number) => {
+    const updatedArtists = showArtists.filter((_, i) => i !== index)
+    onArtistsChange(updatedArtists)
+  }
+
+  const updateArtistPosition = (index: number, position: 'Headliner' | 'Support') => {
+    const updatedArtists = showArtists.map((artist, i) => 
+      i === index ? { ...artist, position } : artist
+    )
+    onArtistsChange(updatedArtists)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-foreground">Show Artists</h3>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setShowSearch(!showSearch)}
+          className="text-green-600 hover:text-green-700 hover:bg-green-50 dark:text-green-400 dark:hover:text-green-300"
+        >
+          <Plus className="w-4 h-4 mr-1" />
+          Add Artist
+        </Button>
+      </div>
+
+      {/* Search Section */}
+      {showSearch && (
+        <div className="space-y-3 p-3 border rounded-lg bg-muted/50">
+          <div className="flex gap-2">
+            <Input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleSearch()
+                }
+              }}
+              placeholder="Search for artist on Spotify..."
+              className="flex-1"
+            />
+            <Button 
+              type="button"
+              onClick={handleSearch} 
+              disabled={searching || !searchQuery.trim()}
+            >
+              <Search className="w-4 h-4 mr-1" />
+              {searching ? 'Searching...' : 'Search'}
+            </Button>
+          </div>
+
+          {/* Search Results */}
+          {searchResults.length > 0 && (
+            <div className="space-y-2 max-h-40 overflow-y-auto">
+              {searchResults.map((artist) => (
+                <div
+                  key={artist.id}
+                  className="flex items-center justify-between p-2 bg-background rounded border"
+                >
+                  <div className="flex items-center space-x-2">
+                    {artist.images[0] && (
+                      <img
+                        src={artist.images[0].url}
+                        alt={artist.name}
+                        className="w-8 h-8 rounded-lg object-cover"
+                      />
+                    )}
+                    <span className="text-sm font-medium">{artist.name}</span>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => addArtist(artist)}
+                    disabled={showArtists.some(a => a.spotify_id === artist.id)}
+                    className="text-xs"
+                  >
+                    {showArtists.some(a => a.spotify_id === artist.id) ? 'Added' : 'Add'}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {searchResults.length === 0 && searchQuery && !searching && (
+            <p className="text-sm text-muted-foreground text-center py-2">
+              No artists found. Try a different search term.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Current Artists */}
+      {showArtists.length > 0 && (
+        <div className="space-y-2">
+          {showArtists.map((artist, index) => (
+            <div key={index} className="flex items-center justify-between p-3 bg-background rounded border">
+              <div className="flex items-center space-x-3">
+                {artist.image_url && (
+                  <img
+                    src={artist.image_url}
+                    alt={artist.artist}
+                    className="w-12 h-12 rounded-lg object-cover"
+                  />
+                )}
+                <div className="flex-1">
+                  <div className="flex items-center space-x-2">
+                    <span className="font-medium">{artist.artist}</span>
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={artist.position === 'Headliner' ? 'default' : 'outline'}
+                      onClick={() => updateArtistPosition(index, 'Headliner')}
+                      className="h-8 px-3 text-xs"
+                    >
+                      Headliner
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={artist.position === 'Support' ? 'default' : 'outline'}
+                      onClick={() => updateArtistPosition(index, 'Support')}
+                      className="h-8 px-3 text-xs"
+                    >
+                      Support
+                    </Button>
+                  </div>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => removeArtist(index)}
+                className="text-red-600 hover:text-red-700 hover:bg-red-50"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showArtists.length === 0 && (
+        <p className="text-sm text-muted-foreground text-center py-4">
+          No artists added yet. Click "Add Artist" to search and add artists from Spotify.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/ShowArtistsManager.tsx
+++ b/components/ShowArtistsManager.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
+import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { ShowArtist } from '@/lib/types'
@@ -143,9 +144,11 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
                 >
                   <div className="flex items-center space-x-2">
                     {artist.images[0] && (
-                      <img
+                      <Image
                         src={artist.images[0].url}
                         alt={artist.name}
+                        width={32}
+                        height={32}
                         className="w-8 h-8 rounded-lg object-cover"
                       />
                     )}
@@ -180,9 +183,11 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
             <div key={index} className="flex items-center justify-between p-3 bg-background rounded border">
               <div className="flex items-center space-x-3">
                 {artist.image_url && (
-                  <img
+                  <Image
                     src={artist.image_url}
                     alt={artist.artist}
+                    width={48}
+                    height={48}
                     className="w-12 h-12 rounded-lg object-cover"
                   />
                 )}
@@ -228,7 +233,7 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
 
       {showArtists.length === 0 && (
         <p className="text-sm text-muted-foreground text-center py-4">
-          No artists added yet. Click "Add Artist" to search and add artists from Spotify.
+          No artists added yet. Click &quot;Add Artist&quot; to search and add artists from Spotify.
         </p>
       )}
     </div>

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -208,6 +208,83 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
           )}
         </div>
 
+        {/* Show Artists */}
+        {show.show_artists && show.show_artists.length > 0 && (
+          <div className="space-y-2">
+            {/* Headliners */}
+            {show.show_artists.filter(artist => artist.position === 'Headliner').length > 0 && (
+              <div className="space-y-2">
+                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Headliner</div>
+                <div className="flex flex-wrap gap-2">
+                  {show.show_artists
+                    .filter(artist => artist.position === 'Headliner')
+                    .map((artist, index) => (
+                    <Button
+                      key={`headliner-${index}`}
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="h-auto p-2 flex items-center space-x-2"
+                    >
+                      <a
+                        href={artist.spotify_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center space-x-2"
+                      >
+                        {artist.image_url && (
+                          <img
+                            src={artist.image_url}
+                            alt={artist.artist}
+                            className="w-6 h-6 rounded-lg object-cover"
+                          />
+                        )}
+                        <span className="text-sm font-medium">{artist.artist}</span>
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+            
+            {/* Support Acts */}
+            {show.show_artists.filter(artist => artist.position === 'Support').length > 0 && (
+              <div className="space-y-2">
+                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Support</div>
+                <div className="flex flex-wrap gap-2">
+                  {show.show_artists
+                    .filter(artist => artist.position === 'Support')
+                    .map((artist, index) => (
+                    <Button
+                      key={`support-${index}`}
+                      variant="outline"
+                      size="sm"
+                      asChild
+                      className="h-auto p-2 flex items-center space-x-2"
+                    >
+                      <a
+                        href={artist.spotify_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center space-x-2"
+                      >
+                        {artist.image_url && (
+                          <img
+                            src={artist.image_url}
+                            alt={artist.artist}
+                            className="w-6 h-6 rounded-lg object-cover"
+                          />
+                        )}
+                        <span className="text-sm font-medium">{artist.artist}</span>
+                      </a>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Action Buttons */}
         <div className="flex flex-wrap gap-2">
           {show.ticket_url && !isPast && (
@@ -245,20 +322,26 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
               </a>
             </Button>
           )}
-          {show.spotify_url && (
+          {/* Only show Spotify button if no show artists (old style) */}
+          {(!show.show_artists || show.show_artists.length === 0) && (
             <Button
               variant="outline"
               size="sm"
               asChild
               className="text-green-800 hover:text-green-900 hover:bg-green-50 dark:text-green-400 dark:hover:text-green-300"
             >
-              <a href={show.spotify_url} target="_blank" rel="noopener noreferrer">
+              <a 
+                href={`https://open.spotify.com/search/${encodeURIComponent(show.title)}`} 
+                target="_blank" 
+                rel="noopener noreferrer"
+              >
                 <SpotifyIcon className="w-4 h-4 mr-1" />
                 Spotify
               </a>
             </Button>
           )}
-          {show.apple_music_url && (
+          {/* Only show Apple Music button if no show artists (old style) */}
+          {(!show.show_artists || show.show_artists.length === 0) && show.apple_music_url && (
             <Button
               variant="outline"
               size="sm"

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -233,9 +233,11 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                         className="flex items-center space-x-2"
                       >
                         {artist.image_url && (
-                          <img
+                          <Image
                             src={artist.image_url}
                             alt={artist.artist}
+                            width={24}
+                            height={24}
                             className="w-6 h-6 rounded-lg object-cover"
                           />
                         )}
@@ -269,9 +271,11 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                         className="flex items-center space-x-2"
                       >
                         {artist.image_url && (
-                          <img
+                          <Image
                             src={artist.image_url}
                             alt={artist.artist}
+                            width={24}
+                            height={24}
                             className="w-6 h-6 rounded-lg object-cover"
                           />
                         )}

--- a/database-complete-setup.sql
+++ b/database-complete-setup.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS shows (
     google_photos_url TEXT,
     poster_url TEXT,
     notes TEXT,
+    show_artists JSONB DEFAULT '[]'::jsonb,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
@@ -95,6 +96,7 @@ CREATE INDEX IF NOT EXISTS idx_releases_release_date ON releases(release_date DE
 CREATE INDEX IF NOT EXISTS idx_releases_spotify_id ON releases(spotify_id);
 CREATE INDEX IF NOT EXISTS idx_user_artists_user_id ON user_artists(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_artists_artist_id ON user_artists(artist_id);
+CREATE INDEX IF NOT EXISTS idx_shows_artists_gin ON shows USING gin(show_artists);
 
 -- Optional indexes for future features (uncomment if needed)
 -- CREATE INDEX IF NOT EXISTS idx_rsvps_name_lower ON rsvps(LOWER(name));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,11 @@
+export interface ShowArtist {
+  artist: string
+  position: 'Headliner' | 'Support'
+  image_url?: string
+  spotify_id: string
+  spotify_url: string
+}
+
 export interface Show {
   id: string
   title: string
@@ -11,6 +19,7 @@ export interface Show {
   google_photos_url?: string | null
   poster_url?: string | null
   notes?: string | null
+  show_artists?: ShowArtist[]
   created_at: string
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
-const STATIC_CACHE = 'show-tracker-static-1758845036039';
-const DYNAMIC_CACHE = 'show-tracker-dynamic-1758845036039';
-const VERSION = 'v2025-09-26T00-03-56-66dfa05'; // Update this when you deploy changes
+const STATIC_CACHE = 'show-tracker-static-1758860129193';
+const DYNAMIC_CACHE = 'show-tracker-dynamic-1758860129193';
+const VERSION = 'v2025-09-26T04-15-29-9584ad7'; // Update this when you deploy changes
 
 const urlsToCache = [
   '/',


### PR DESCRIPTION
This pull request introduces comprehensive enhancements to artist statistics tracking and display throughout the application. The main changes include adding personal and group artist stats to the recap API and UI, refactoring artist data handling for shows, and removing unused music platform URL fields from show creation and editing. Together, these updates allow users to view richer insights about the artists they've seen and group-wide artist diversity.

**Artist Statistics Enhancements**

* Added personal and group artist statistics to the `RecapData` API response, including top artists, most seen artist, unique artist counts, and artist diversity ratios for both individuals and the group. Also included a "most diverse user" metric. [[1]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R73-R86) [[2]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R120-R137)
* Implemented helper functions (`extractArtistsFromShow`, `calculateUserArtistStats`, `calculateGroupArtistStats`) to aggregate artist data from shows and RSVPs, supporting the new recap statistics.
* Updated the recap API logic to compute and return these new artist stats for both the current user and the group. [[1]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R690-R718) [[2]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R977-R1030) [[3]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R1044-R1049) [[4]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8L807-R1067)

**Show Data Model Updates**

* Refactored show creation (`app/api/shows/route.ts`) and editing (`app/api/shows/[id]/route.ts`) endpoints to accept and store a new `show_artists` field, removing `spotify_url` and `apple_music_url` fields and their validations. [[1]](diffhunk://#diff-e44f28f4a2e50d48fb150584100eef3b02fbc90cec48a40f3b63d9a394047505L18-R18) [[2]](diffhunk://#diff-e44f28f4a2e50d48fb150584100eef3b02fbc90cec48a40f3b63d9a394047505L51-L59) [[3]](diffhunk://#diff-e44f28f4a2e50d48fb150584100eef3b02fbc90cec48a40f3b63d9a394047505L90-R84) [app/api/shows/[id]/route.tsL59-R59](diffhunk://#diff-21534b6e44dfb36a5636eaf44df0892db643022d2bebc0b57cb89d7899843b79L59-R59), [app/api/shows/[id]/route.tsL99-L107](diffhunk://#diff-21534b6e44dfb36a5636eaf44df0892db643022d2bebc0b57cb89d7899843b79L99-L107), [app/api/shows/[id]/route.tsL137-R131](diffhunk://#diff-21534b6e44dfb36a5636eaf44df0892db643022d2bebc0b57cb89d7899843b79L137-R131))

**Recap UI Improvements**

* Enhanced the recap page UI to display personal artist diversity, most seen artist, and top artists with images, making use of the new API fields and the Next.js `Image` component. [[1]](diffhunk://#diff-5ea9af6728d4362c09efb7b149e6734dfd3f16b16b68252d9701c79a46e10118R5) [[2]](diffhunk://#diff-5ea9af6728d4362c09efb7b149e6734dfd3f16b16b68252d9701c79a46e10118R475-R536)

**Spotify Search Endpoint Minor Update**

* Adjusted the Spotify artist search API to always return an array of artists (default limit 10), and improved error handling and configuration checks.