### PR TITLE
Local support

### DIFF
--- a/app/api/recap/route.ts
+++ b/app/api/recap/route.ts
@@ -366,6 +366,7 @@ function calculateUserArtistStats(userShows: Array<{
   const artistCounts = new Map<string, {
     count: number
     image_url?: string
+    isHeadliner: boolean
   }>()
   
   userShows.forEach(show => {
@@ -375,26 +376,44 @@ function calculateUserArtistStats(userShows: Array<{
       const artistName = artistData.artist
       if (!artistName) return
       
+      const isHeadliner = artistData.position === 'Headliner'
+      
       // Overall artist counts
       if (!artistCounts.has(artistName)) {
         artistCounts.set(artistName, {
           count: 0,
-          image_url: artistData.image_url
+          image_url: artistData.image_url,
+          isHeadliner: false
         })
       }
       const artistStat = artistCounts.get(artistName)!
       artistStat.count++
+      // If this artist has ever been a headliner, mark them as such
+      if (isHeadliner) {
+        artistStat.isHeadliner = true
+      }
     })
   })
   
-  // Convert to sorted arrays
+  // Convert to sorted arrays, prioritizing headliners
   const topArtists = Array.from(artistCounts.entries())
     .map(([artist, data]) => ({
       artist,
       count: data.count,
-      image_url: data.image_url
+      image_url: data.image_url,
+      isHeadliner: data.isHeadliner
     }))
-    .sort((a, b) => b.count - a.count)
+    .sort((a, b) => {
+      // First sort by count (descending)
+      if (b.count !== a.count) {
+        return b.count - a.count
+      }
+      // If counts are equal, prioritize headliners
+      if (a.isHeadliner && !b.isHeadliner) return -1
+      if (!a.isHeadliner && b.isHeadliner) return 1
+      // If both are headliners or both are not, sort alphabetically
+      return a.artist.localeCompare(b.artist)
+    })
     .slice(0, 10)
   
   const mostSeenArtist = topArtists.length > 0 ? topArtists[0] : null
@@ -420,6 +439,7 @@ function calculateGroupArtistStats(shows: Array<{
   const artistCounts = new Map<string, {
     count: number
     image_url?: string
+    isHeadliner: boolean
   }>()
   
   shows.forEach(show => {
@@ -430,26 +450,44 @@ function calculateGroupArtistStats(shows: Array<{
       const artistName = artistData.artist
       if (!artistName) return
       
+      const isHeadliner = artistData.position === 'Headliner'
+      
       // Each person attending counts as 1 entry for this artist
       if (!artistCounts.has(artistName)) {
         artistCounts.set(artistName, {
           count: 0,
-          image_url: artistData.image_url
+          image_url: artistData.image_url,
+          isHeadliner: false
         })
       }
       const artistStat = artistCounts.get(artistName)!
       artistStat.count += attendingCount
+      // If this artist has ever been a headliner, mark them as such
+      if (isHeadliner) {
+        artistStat.isHeadliner = true
+      }
     })
   })
   
-  // Convert to sorted arrays
+  // Convert to sorted arrays, prioritizing headliners
   const topArtists = Array.from(artistCounts.entries())
     .map(([artist, data]) => ({
       artist,
       count: data.count,
-      image_url: data.image_url
+      image_url: data.image_url,
+      isHeadliner: data.isHeadliner
     }))
-    .sort((a, b) => b.count - a.count)
+    .sort((a, b) => {
+      // First sort by count (descending)
+      if (b.count !== a.count) {
+        return b.count - a.count
+      }
+      // If counts are equal, prioritize headliners
+      if (a.isHeadliner && !b.isHeadliner) return -1
+      if (!a.isHeadliner && b.isHeadliner) return 1
+      // If both are headliners or both are not, sort alphabetically
+      return a.artist.localeCompare(b.artist)
+    })
     .slice(0, 10)
   
   const mostSeenArtist = topArtists.length > 0 ? topArtists[0] : null

--- a/app/recap/page.tsx
+++ b/app/recap/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectOption, SelectTrigger } from '@/components/ui/select'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { LogOut, Copy, Plus, Menu } from 'lucide-react'
 import * as DropdownMenu from '@/components/ui/dropdown-menu'
@@ -500,38 +501,175 @@ export default function RecapPage() {
                   <div className="space-y-4">
                     <h4 className="font-semibold text-lg text-foreground">Your Artist Stats</h4>
                     
-                    {/* Top Artists */}
-                    {recapData.stats.personalTopArtists.length > 0 && (
-                      <div className="space-y-3">
-                        <h5 className="font-medium text-foreground">Your Top Artists</h5>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                          {recapData.stats.personalTopArtists.slice(0, 8).map((artist, index) => (
-                            <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
-                              <div className="text-sm font-medium text-muted-foreground w-6">
-                                {index + 1}
-                              </div>
-                              {artist.image_url && (
-                                <Image 
-                                  src={artist.image_url} 
-                                  alt={artist.artist}
-                                  width={32}
-                                  height={32}
-                                  className="w-8 h-8 rounded-full object-cover"
-                                />
-                              )}
-                              <div className="flex-1 min-w-0">
-                                <div className="font-medium text-foreground truncate">
-                                  {artist.artist}
+                    {/* Artist Stats Tabs */}
+                    <Tabs defaultValue="all" className="w-full">
+                      <TabsList className="grid w-full grid-cols-4">
+                        <TabsTrigger value="all">
+                          All
+                        </TabsTrigger>
+                        <TabsTrigger value="headliner">
+                          Headliners
+                        </TabsTrigger>
+                        <TabsTrigger value="support">
+                          Support
+                        </TabsTrigger>
+                        <TabsTrigger value="local">
+                          Local
+                        </TabsTrigger>
+                      </TabsList>
+                      
+                      {/* All Artists Tab */}
+                      <TabsContent value="all" className="space-y-3">
+                        {recapData.stats.personalTopArtists.length > 0 && (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Your Top Artists</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.personalTopArtists.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
                                 </div>
-                                <div className="text-xs text-muted-foreground">
-                                  {artist.count} show{artist.count !== 1 ? 's' : ''}
-                                </div>
-                              </div>
+                              ))}
                             </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Headliners Tab */}
+                      <TabsContent value="headliner" className="space-y-3">
+                        {recapData.stats.personalTopArtistsByPosition.Headliner.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Your Top Headliners</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.personalTopArtistsByPosition.Headliner.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No headliners seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Support Tab */}
+                      <TabsContent value="support" className="space-y-3">
+                        {recapData.stats.personalTopArtistsByPosition.Support.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Your Top Support Acts</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.personalTopArtistsByPosition.Support.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No support acts seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Local Tab */}
+                      <TabsContent value="local" className="space-y-3">
+                        {recapData.stats.personalTopArtistsByPosition.Local.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Your Top Local Acts</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.personalTopArtistsByPosition.Local.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No local acts seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                    </Tabs>
                   </div>
 
                   {/* Group Stats */}
@@ -662,38 +800,175 @@ export default function RecapPage() {
                   <div className="space-y-4">
                     <h4 className="font-semibold text-lg text-foreground">Group Artist Stats</h4>
                     
-                    {/* Group Top Artists */}
-                    {recapData.stats.groupTopArtists.length > 0 && (
-                      <div className="space-y-3">
-                        <h5 className="font-medium text-foreground">Group Top Artists</h5>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                          {recapData.stats.groupTopArtists.slice(0, 8).map((artist, index) => (
-                            <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
-                              <div className="text-sm font-medium text-muted-foreground w-6">
-                                {index + 1}
-                              </div>
-                              {artist.image_url && (
-                                <Image 
-                                  src={artist.image_url} 
-                                  alt={artist.artist}
-                                  width={32}
-                                  height={32}
-                                  className="w-8 h-8 rounded-full object-cover"
-                                />
-                              )}
-                              <div className="flex-1 min-w-0">
-                                <div className="font-medium text-foreground truncate">
-                                  {artist.artist}
+                    {/* Group Artist Stats Tabs */}
+                    <Tabs defaultValue="all" className="w-full">
+                      <TabsList className="grid w-full grid-cols-4">
+                        <TabsTrigger value="all">
+                          All
+                        </TabsTrigger>
+                        <TabsTrigger value="headliner">
+                          Headliners
+                        </TabsTrigger>
+                        <TabsTrigger value="support">
+                          Support
+                        </TabsTrigger>
+                        <TabsTrigger value="local">
+                          Local
+                        </TabsTrigger>
+                      </TabsList>
+                      
+                      {/* All Artists Tab */}
+                      <TabsContent value="all" className="space-y-3">
+                        {recapData.stats.groupTopArtists.length > 0 && (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Group Top Artists</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.groupTopArtists.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
                                 </div>
-                                <div className="text-xs text-muted-foreground">
-                                  {artist.count} show{artist.count !== 1 ? 's' : ''}
-                                </div>
-                              </div>
+                              ))}
                             </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Headliners Tab */}
+                      <TabsContent value="headliner" className="space-y-3">
+                        {recapData.stats.groupTopArtistsByPosition.Headliner.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Group Top Headliners</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.groupTopArtistsByPosition.Headliner.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No headliners seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Support Tab */}
+                      <TabsContent value="support" className="space-y-3">
+                        {recapData.stats.groupTopArtistsByPosition.Support.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Group Top Support Acts</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.groupTopArtistsByPosition.Support.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No support acts seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                      
+                      {/* Local Tab */}
+                      <TabsContent value="local" className="space-y-3">
+                        {recapData.stats.groupTopArtistsByPosition.Local.length > 0 ? (
+                          <div className="space-y-3">
+                            <h5 className="font-medium text-foreground">Group Top Local Acts</h5>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              {recapData.stats.groupTopArtistsByPosition.Local.slice(0, 8).map((artist, index) => (
+                                <div key={artist.artist} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
+                                  <div className="text-sm font-medium text-muted-foreground w-6">
+                                    {index + 1}
+                                  </div>
+                                  {artist.image_url && (
+                                    <Image 
+                                      src={artist.image_url} 
+                                      alt={artist.artist}
+                                      width={32}
+                                      height={32}
+                                      className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                  )}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-medium text-foreground truncate">
+                                      {artist.artist}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                    </div>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-center text-muted-foreground py-8">
+                            No local acts seen this year
+                          </div>
+                        )}
+                      </TabsContent>
+                    </Tabs>
                   </div>
                 </CardContent>
               </Card>

--- a/app/recap/page.tsx
+++ b/app/recap/page.tsx
@@ -789,7 +789,7 @@ export default function RecapPage() {
                           {recapData.stats.groupMostSeenArtist?.artist || 'N/A'}
                         </div>
                         <div className="text-xs text-muted-foreground mt-1">
-                          {recapData.stats.groupMostSeenArtist?.count || 0} times
+                          {recapData.stats.groupMostSeenArtist?.count || 0} {recapData.stats.groupMostSeenArtist?.count !== 1 ? 'times seen' : 'time seen'}
                         </div>
                       </div>
                       
@@ -842,7 +842,7 @@ export default function RecapPage() {
                                       {artist.artist}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
-                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                      {artist.count} {artist.count !== 1 ? 'times seen' : 'time seen'}
                                     </div>
                                   </div>
                                 </div>
@@ -877,7 +877,7 @@ export default function RecapPage() {
                                       {artist.artist}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
-                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                      {artist.count} {artist.count !== 1 ? 'times seen' : 'time seen'}
                                     </div>
                                   </div>
                                 </div>
@@ -916,7 +916,7 @@ export default function RecapPage() {
                                       {artist.artist}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
-                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                      {artist.count} {artist.count !== 1 ? 'times seen' : 'time seen'}
                                     </div>
                                   </div>
                                 </div>
@@ -955,7 +955,7 @@ export default function RecapPage() {
                                       {artist.artist}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
-                                      {artist.count} show{artist.count !== 1 ? 's' : ''}
+                                      {artist.count} {artist.count !== 1 ? 'times seen' : 'time seen'}
                                     </div>
                                   </div>
                                 </div>

--- a/components/ShowArtistsManager.tsx
+++ b/components/ShowArtistsManager.tsx
@@ -88,7 +88,7 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
     const newArtist: ShowArtist = {
       artist: searchQuery.trim(),
       position: isFirstArtist ? 'Headliner' : 'Support',
-      image_url: '',
+      image_url: 'https://dorosdstv5ifoevu.public.blob.vercel-storage.com/ab6761610000e5eb359a5c25a8bbfe678cc4fd0e.webp',
       spotify_id: '',
       spotify_url: ''
     }

--- a/components/ShowArtistsManager.tsx
+++ b/components/ShowArtistsManager.tsx
@@ -104,7 +104,7 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
     onArtistsChange(updatedArtists)
   }
 
-  const updateArtistPosition = (index: number, position: 'Headliner' | 'Support') => {
+  const updateArtistPosition = (index: number, position: 'Headliner' | 'Support' | 'Local') => {
     const updatedArtists = showArtists.map((artist, i) => 
       i === index ? { ...artist, position } : artist
     )
@@ -253,24 +253,33 @@ export function ShowArtistsManager({ showArtists, onArtistsChange }: ShowArtists
                       </span>
                     )}
                   </div>
-                  <div className="flex gap-1">
+                  <div className="flex border rounded-md overflow-hidden mt-1">
                     <Button
                       type="button"
                       size="sm"
-                      variant={artist.position === 'Headliner' ? 'default' : 'outline'}
+                      variant={artist.position === 'Headliner' ? 'default' : 'ghost'}
                       onClick={() => updateArtistPosition(index, 'Headliner')}
-                      className="h-8 px-3 text-xs"
+                      className="h-8 px-3 text-xs rounded-none border-0"
                     >
                       Headliner
                     </Button>
                     <Button
                       type="button"
                       size="sm"
-                      variant={artist.position === 'Support' ? 'default' : 'outline'}
+                      variant={artist.position === 'Support' ? 'default' : 'ghost'}
                       onClick={() => updateArtistPosition(index, 'Support')}
-                      className="h-8 px-3 text-xs"
+                      className="h-8 px-3 text-xs rounded-none border-0 border-l"
                     >
                       Support
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={artist.position === 'Local' ? 'default' : 'ghost'}
+                      onClick={() => updateArtistPosition(index, 'Local')}
+                      className="h-8 px-3 text-xs rounded-none border-0 border-l"
+                    >
+                      Local
                     </Button>
                   </div>
                 </div>

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -48,8 +48,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
       show.title,
       '',
       formatUserTime(show.date_time, show.time_local),
-      show.venue,
-      show.city
+      `${show.venue}, ${show.city}`
     ]
 
     // Add headliner and support information
@@ -70,6 +69,15 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
       if (supportActs.length > 0) {
         lines.push('Support:')
         supportActs.forEach(artist => {
+          lines.push(`  • ${artist.artist}`)
+        })
+      }
+      
+      // Local acts
+      const localActs = show.show_artists.filter(artist => artist.position === 'Local')
+      if (localActs.length > 0) {
+        lines.push('Local Support:')
+        localActs.forEach(artist => {
           lines.push(`  • ${artist.artist}`)
         })
       }
@@ -313,6 +321,73 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                     .map((artist, index) => (
                      <Button
                        key={`support-${index}`}
+                       variant="outline"
+                       size="sm"
+                       asChild={!!artist.spotify_url}
+                       className="h-auto p-2 flex items-center space-x-2"
+                     >
+                       {artist.spotify_url ? (
+                         <a
+                           href={artist.spotify_url}
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           className="flex items-center space-x-2"
+                         >
+                           {artist.image_url ? (
+                             <Image
+                               src={artist.image_url}
+                               alt={artist.artist}
+                               width={24}
+                               height={24}
+                               className="w-6 h-6 rounded-lg object-cover"
+                             />
+                           ) : (
+                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
+                               <Music className="w-3 h-3 text-muted-foreground" />
+                             </div>
+                           )}
+                           <span className="text-sm font-medium">{artist.artist}</span>
+                         </a>
+                       ) : (
+                         <div className="flex items-center space-x-2">
+                           {artist.image_url ? (
+                             <Image
+                               src={artist.image_url}
+                               alt={artist.artist}
+                               width={24}
+                               height={24}
+                               className="w-6 h-6 rounded-lg object-cover"
+                             />
+                           ) : (
+                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
+                               <Music className="w-3 h-3 text-muted-foreground" />
+                             </div>
+                           )}
+                           <span className="text-sm font-medium">{artist.artist}</span>
+                         </div>
+                       )}
+                     </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+            
+            {/* Local Acts */}
+            {show.show_artists.filter(artist => artist.position === 'Local').length > 0 && (
+              <div className="space-y-2">
+                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Local Support</div>
+                <div className="flex flex-wrap gap-2">
+                  {show.show_artists
+                    .filter(artist => artist.position === 'Local')
+                    .sort((a, b) => {
+                      // Sort Spotify artists first, then custom artists
+                      if (a.spotify_id && !b.spotify_id) return -1
+                      if (!a.spotify_id && b.spotify_id) return 1
+                      return 0
+                    })
+                    .map((artist, index) => (
+                     <Button
+                       key={`local-${index}`}
                        variant="outline"
                        size="sm"
                        asChild={!!artist.spotify_url}

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card'
 import { Show, RSVPSummary } from '@/lib/types'
 import { formatUserTime } from '@/lib/time'
 import { formatNameForDisplay } from '@/lib/validation'
@@ -172,18 +172,28 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
     : null
 
   return (
-    <Card className="w-full mb-4">
-      <CardContent className="p-4 space-y-3">
-        {/* Header with Title and Actions */}
-        <div className="flex justify-between items-start">
-          <h3 className="text-xl font-bold text-foreground">{show.title}</h3>
+    <Card className="w-full mb-6 overflow-hidden">
+      {/* Header Section */}
+      <CardHeader className="pb-4">
+        <div className="flex justify-between items-start gap-4">
+          <div className="flex-1 min-w-0">
+            <CardTitle className="text-xl font-bold leading-tight mb-2">
+              {show.title}
+            </CardTitle>
+            <CardDescription className="text-base font-medium">
+              {formatUserTime(show.date_time, show.time_local)}
+            </CardDescription>
+            <div className="text-sm text-muted-foreground mt-1">
+              {show.venue} • {show.city}
+            </div>
+          </div>
           {(onEdit || (onDelete && !isPast)) && (
             <DropdownMenu.DropdownMenu>
               <DropdownMenu.DropdownMenuTrigger asChild>
                 <Button 
                   variant="ghost" 
                   size="sm" 
-                  className="h-8 w-8 p-0"
+                  className="h-8 w-8 p-0 flex-shrink-0"
                   aria-label={`More options for ${show.title}`}
                 >
                   <MoreVertical className="h-4 w-4" />
@@ -209,39 +219,40 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
             </DropdownMenu.DropdownMenu>
           )}
         </div>
+      </CardHeader>
 
+      {/* Main Content Section */}
+      <CardContent className="space-y-6">
         {/* Poster Image */}
         {show.poster_url && (
-          <div className="w-full">
+          <div className="w-full -mx-6">
             <Image
               src={show.poster_url}
               alt={`${show.title} poster`}
               width={400}
               height={320}
-              className="w-full max-h-80 object-contain rounded-lg bg-gray-50 dark:bg-gray-800 cursor-pointer hover:opacity-90 transition-opacity"
+              className="w-full max-h-80 object-contain cursor-pointer"
               onClick={() => setImageModalOpen(true)}
             />
           </div>
         )}
 
-        {/* Date/Time, Venue, and Location */}
-        <div>
-          <div className="text-lg font-semibold text-foreground">
-            {formatUserTime(show.date_time, show.time_local)}
+        {/* Notes Section */}
+        {show.notes && (
+          <div className="bg-muted/50 rounded-lg p-3 border-l-4 border-muted-foreground/20">
+            <p className="text-sm text-muted-foreground italic">{show.notes}</p>
           </div>
-          <p className="text-muted-foreground">{show.venue}, {show.city}</p>
-          {show.notes && (
-            <p className="text-sm text-muted-foreground italic mt-1">{show.notes}</p>
-          )}
-        </div>
+        )}
 
         {/* Show Artists */}
         {show.show_artists && show.show_artists.length > 0 && (
-          <div className="space-y-2">
+          <div className="space-y-4">
             {/* Headliners */}
             {show.show_artists.filter(artist => artist.position === 'Headliner').length > 0 && (
-              <div className="space-y-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Headliner</div>
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
+                  Headliner
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Headliner')
@@ -257,7 +268,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                       variant="outline"
                       size="sm"
                       asChild={!!artist.spotify_url}
-                      className="h-auto p-2 flex items-center space-x-2"
+                      className="h-auto p-3 flex items-center space-x-2 rounded-lg"
                     >
                       {artist.spotify_url ? (
                         <a
@@ -270,13 +281,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                             <Image
                               src={artist.image_url}
                               alt={artist.artist}
-                              width={24}
-                              height={24}
-                              className="w-6 h-6 rounded-lg object-cover"
+                              width={28}
+                              height={28}
+                              className="w-7 h-7 rounded-full object-cover"
                             />
                           ) : (
-                            <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                              <Music className="w-3 h-3 text-muted-foreground" />
+                            <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                              <Music className="w-4 h-4 text-muted-foreground" />
                             </div>
                           )}
                           <span className="text-sm font-medium">{artist.artist}</span>
@@ -287,13 +298,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                             <Image
                               src={artist.image_url}
                               alt={artist.artist}
-                              width={24}
-                              height={24}
-                              className="w-6 h-6 rounded-lg object-cover"
+                              width={28}
+                              height={28}
+                              className="w-7 h-7 rounded-full object-cover"
                             />
                           ) : (
-                            <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                              <Music className="w-3 h-3 text-muted-foreground" />
+                            <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                              <Music className="w-4 h-4 text-muted-foreground" />
                             </div>
                           )}
                           <span className="text-sm font-medium">{artist.artist}</span>
@@ -307,8 +318,10 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
             
             {/* Support Acts */}
             {show.show_artists.filter(artist => artist.position === 'Support').length > 0 && (
-              <div className="space-y-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Support</div>
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
+                  Support
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Support')
@@ -324,7 +337,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                        variant="outline"
                        size="sm"
                        asChild={!!artist.spotify_url}
-                       className="h-auto p-2 flex items-center space-x-2"
+                       className="h-auto p-3 flex items-center space-x-2 rounded-lg"
                      >
                        {artist.spotify_url ? (
                          <a
@@ -337,13 +350,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                              <Image
                                src={artist.image_url}
                                alt={artist.artist}
-                               width={24}
-                               height={24}
-                               className="w-6 h-6 rounded-lg object-cover"
+                               width={28}
+                               height={28}
+                               className="w-7 h-7 rounded-full object-cover"
                              />
                            ) : (
-                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                               <Music className="w-3 h-3 text-muted-foreground" />
+                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                               <Music className="w-4 h-4 text-muted-foreground" />
                              </div>
                            )}
                            <span className="text-sm font-medium">{artist.artist}</span>
@@ -354,13 +367,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                              <Image
                                src={artist.image_url}
                                alt={artist.artist}
-                               width={24}
-                               height={24}
-                               className="w-6 h-6 rounded-lg object-cover"
+                               width={28}
+                               height={28}
+                               className="w-7 h-7 rounded-full object-cover"
                              />
                            ) : (
-                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                               <Music className="w-3 h-3 text-muted-foreground" />
+                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                               <Music className="w-4 h-4 text-muted-foreground" />
                              </div>
                            )}
                            <span className="text-sm font-medium">{artist.artist}</span>
@@ -374,8 +387,10 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
             
             {/* Local Acts */}
             {show.show_artists.filter(artist => artist.position === 'Local').length > 0 && (
-              <div className="space-y-2">
-                <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Local Support</div>
+              <div className="space-y-3">
+                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
+                  Local Support
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Local')
@@ -391,7 +406,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                        variant="outline"
                        size="sm"
                        asChild={!!artist.spotify_url}
-                       className="h-auto p-2 flex items-center space-x-2"
+                       className="h-auto p-3 flex items-center space-x-2 rounded-lg"
                      >
                        {artist.spotify_url ? (
                          <a
@@ -404,13 +419,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                              <Image
                                src={artist.image_url}
                                alt={artist.artist}
-                               width={24}
-                               height={24}
-                               className="w-6 h-6 rounded-lg object-cover"
+                               width={28}
+                               height={28}
+                               className="w-7 h-7 rounded-full object-cover"
                              />
                            ) : (
-                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                               <Music className="w-3 h-3 text-muted-foreground" />
+                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                               <Music className="w-4 h-4 text-muted-foreground" />
                              </div>
                            )}
                            <span className="text-sm font-medium">{artist.artist}</span>
@@ -421,13 +436,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                              <Image
                                src={artist.image_url}
                                alt={artist.artist}
-                               width={24}
-                               height={24}
-                               className="w-6 h-6 rounded-lg object-cover"
+                               width={28}
+                               height={28}
+                               className="w-7 h-7 rounded-full object-cover"
                              />
                            ) : (
-                             <div className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center">
-                               <Music className="w-3 h-3 text-muted-foreground" />
+                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
+                               <Music className="w-4 h-4 text-muted-foreground" />
                              </div>
                            )}
                            <span className="text-sm font-medium">{artist.artist}</span>
@@ -441,17 +456,62 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
           </div>
         )}
 
+        {/* RSVPs Section */}
+        {(rsvps?.going?.length > 0 || rsvps?.maybe?.length > 0 || rsvps?.not_going?.length > 0) && (
+          <div className="space-y-3">
+            <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
+              {isPast ? 'Attendance' : 'RSVPs'}
+            </div>
+            <div className="space-y-2 text-sm">
+              {rsvps?.going?.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-foreground">
+                    {isPast ? 'Went:' : 'Going:'}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {rsvps.going.map(formatNameForDisplay).join(', ')}
+                  </span>
+                </div>
+              )}
+              {rsvps?.maybe?.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-foreground">
+                    Maybe:
+                  </span>
+                  <span className="text-muted-foreground">
+                    {rsvps.maybe.map(formatNameForDisplay).join(', ')}
+                  </span>
+                </div>
+              )}
+              {rsvps?.not_going?.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-foreground">
+                    {isPast ? "Didn't Go:" : 'Not Going:'}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {rsvps.not_going.map(formatNameForDisplay).join(', ')}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </CardContent>
+
+      {/* Footer Section */}
+      <CardFooter className="flex-col gap-4 pt-0">
         {/* Action Buttons */}
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 w-full">
           {show.ticket_url && !isPast && (
             <Button
               variant="outline"
               size="sm"
               asChild
+              className="flex-1 sm:flex-none"
             >
               <a href={show.ticket_url} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="w-4 h-4 mr-1" />
-                Ticket
+                <ExternalLink className="w-4 h-4 mr-2" />
+                Get Tickets
               </a>
             </Button>
           )}
@@ -460,20 +520,20 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
             variant="outline"
             size="sm"
             onClick={handleCopyShowInfo}
-            className="text-blue-800 hover:text-blue-900 hover:bg-blue-50 dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-blue-950/20"
+            className="flex-1 sm:flex-none"
           >
-            <Copy className="w-4 h-4 mr-1" />
-            {copySuccess ? 'Copied!' : 'Copy'}
+            <Copy className="w-4 h-4 mr-2" />
+            {copySuccess ? 'Copied!' : 'Copy Info'}
           </Button>
           {show.google_photos_url && isPast && (
             <Button
               variant="outline"
               size="sm"
               asChild
-              className="text-blue-800 hover:text-blue-900 hover:bg-blue-50 dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-blue-950/20"
+              className="flex-1 sm:flex-none"
             >
               <a href={show.google_photos_url} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="w-4 h-4 mr-1" />
+                <ExternalLink className="w-4 h-4 mr-2" />
                 Photos
               </a>
             </Button>
@@ -484,46 +544,27 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
               variant="outline"
               size="sm"
               asChild
-              className="text-red-800 hover:text-red-900 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300"
+              className="flex-1 sm:flex-none"
             >
               <a href={show.apple_music_url} target="_blank" rel="noopener noreferrer">
-                <AppleMusicIcon className="w-4 h-4 mr-1" />
+                <AppleMusicIcon className="w-4 h-4 mr-2" />
                 Apple Music
               </a>
             </Button>
           )}
         </div>
 
-        {/* RSVPs */}
-        <div className="space-y-2 text-sm text-foreground">
-          {rsvps?.going?.length > 0 && (
-            <div>
-              <span className="font-semibold">{isPast ? 'Went:' : 'Going:'}</span> {rsvps.going.map(formatNameForDisplay).join(', ')}
-            </div>
-          )}
-          {rsvps?.maybe?.length > 0 && (
-            <div>
-              <span className="font-semibold">Maybe:</span> {rsvps.maybe.map(formatNameForDisplay).join(', ')}
-            </div>
-          )}
-          {rsvps?.not_going?.length > 0 && (
-            <div>
-              <span className="font-semibold">{isPast ? "Didn't Go:" : 'Not Going:'}</span> {rsvps.not_going.map(formatNameForDisplay).join(', ')}
-            </div>
-          )}
-        </div>
-
         {/* RSVP Buttons (only for upcoming shows) */}
         {!isPast && userName && (
-          <div className="pt-2 border-t border-border">
-            <div className="text-sm text-muted-foreground mb-2">Your RSVP:</div>
-            <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
+          <div className="w-full space-y-3">
+            <div className="text-sm font-medium text-foreground">Your RSVP:</div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
               <Button
                 size="sm"
                 variant={userStatus === 'going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
                 disabled={loading}
-                className="w-full sm:w-auto"
+                className="w-full"
               >
                 Going
               </Button>
@@ -532,7 +573,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                 variant={userStatus === 'maybe' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'maybe' ? null : 'maybe')}
                 disabled={loading}
-                className="w-full sm:w-auto"
+                className="w-full"
               >
                 Maybe
               </Button>
@@ -541,37 +582,38 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                 variant={userStatus === 'not_going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'not_going' ? null : 'not_going')}
                 disabled={loading}
-                className="w-full sm:w-auto"
+                className="w-full"
               >
                 Not Going
               </Button>
-              {userStatus && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => handleRSVP(null)}
-                  disabled={loading}
-                  className="w-full sm:w-auto"
-                >
-                  Clear
-                </Button>
-              )}
             </div>
+            {userStatus && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => handleRSVP(null)}
+                disabled={loading}
+                className="w-full"
+              >
+                Clear RSVP
+              </Button>
+            )}
           </div>
         )}
 
         {/* Attendance Button (only for past shows) */}
         {isPast && userName && (
-          <div className="pt-2 border-t border-border">
-            <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
+          <div className="w-full space-y-3">
+            <div className="text-sm font-medium text-foreground">Attendance:</div>
+            <div className="flex gap-2">
               <Button
                 size="sm"
                 variant={userStatus === 'going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
                 disabled={loading}
-                className="w-full sm:w-auto"
+                className="flex-1"
               >
-                {userStatus === 'going' ? 'I was there!' : 'I was there!'}
+                {userStatus === 'going' ? 'I was there!' : 'Mark as Attended'}
               </Button>
               {userStatus === 'going' && (
                 <Button
@@ -579,7 +621,6 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                   variant="ghost"
                   onClick={() => handleRSVP(null)}
                   disabled={loading}
-                  className="w-full sm:w-auto"
                 >
                   Clear
                 </Button>
@@ -587,7 +628,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
             </div>
           </div>
         )}
-      </CardContent>
+      </CardFooter>
       
       {/* Image Modal */}
       {show.poster_url && (

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -246,13 +246,11 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
 
         {/* Show Artists */}
         {show.show_artists && show.show_artists.length > 0 && (
-          <div className="space-y-4">
+          <div className="space-y-3">
             {/* Headliners */}
             {show.show_artists.filter(artist => artist.position === 'Headliner').length > 0 && (
-              <div className="space-y-3">
-                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
-                  Headliner
-                </div>
+              <div className="space-y-2">
+                <div className="text-sm font-semibold text-foreground">Headliner</div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Headliner')
@@ -263,65 +261,35 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                       return 0
                     })
                     .map((artist, index) => (
-                    <Button
-                      key={`headliner-${index}`}
-                      variant="outline"
-                      size="sm"
-                      asChild={!!artist.spotify_url}
-                      className="h-auto p-3 flex items-center space-x-2 rounded-lg"
-                    >
-                      {artist.spotify_url ? (
-                        <a
-                          href={artist.spotify_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center space-x-2"
-                        >
-                          {artist.image_url ? (
-                            <Image
-                              src={artist.image_url}
-                              alt={artist.artist}
-                              width={28}
-                              height={28}
-                              className="w-7 h-7 rounded-full object-cover"
-                            />
-                          ) : (
-                            <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                              <Music className="w-4 h-4 text-muted-foreground" />
-                            </div>
-                          )}
-                          <span className="text-sm font-medium">{artist.artist}</span>
-                        </a>
-                      ) : (
-                        <div className="flex items-center space-x-2">
-                          {artist.image_url ? (
-                            <Image
-                              src={artist.image_url}
-                              alt={artist.artist}
-                              width={28}
-                              height={28}
-                              className="w-7 h-7 rounded-full object-cover"
-                            />
-                          ) : (
-                            <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                              <Music className="w-4 h-4 text-muted-foreground" />
-                            </div>
-                          )}
-                          <span className="text-sm font-medium">{artist.artist}</span>
-                        </div>
-                      )}
-                    </Button>
-                  ))}
+                      <div
+                        key={`headliner-${index}`}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg border bg-muted/30 ${artist.spotify_url ? 'cursor-pointer' : ''}`}
+                        onClick={() => artist.spotify_url && window.open(artist.spotify_url, '_blank')}
+                      >
+                        {artist.image_url ? (
+                          <Image
+                            src={artist.image_url}
+                            alt={artist.artist}
+                            width={24}
+                            height={24}
+                            className="w-6 h-6 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+                            <Music className="w-3 h-3 text-muted-foreground" />
+                          </div>
+                        )}
+                        <span className="text-sm font-medium">{artist.artist}</span>
+                      </div>
+                    ))}
                 </div>
               </div>
             )}
             
             {/* Support Acts */}
             {show.show_artists.filter(artist => artist.position === 'Support').length > 0 && (
-              <div className="space-y-3">
-                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
-                  Support
-                </div>
+              <div className="space-y-2">
+                <div className="text-sm font-semibold text-foreground">Support</div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Support')
@@ -332,65 +300,35 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                       return 0
                     })
                     .map((artist, index) => (
-                     <Button
-                       key={`support-${index}`}
-                       variant="outline"
-                       size="sm"
-                       asChild={!!artist.spotify_url}
-                       className="h-auto p-3 flex items-center space-x-2 rounded-lg"
-                     >
-                       {artist.spotify_url ? (
-                         <a
-                           href={artist.spotify_url}
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           className="flex items-center space-x-2"
-                         >
-                           {artist.image_url ? (
-                             <Image
-                               src={artist.image_url}
-                               alt={artist.artist}
-                               width={28}
-                               height={28}
-                               className="w-7 h-7 rounded-full object-cover"
-                             />
-                           ) : (
-                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                               <Music className="w-4 h-4 text-muted-foreground" />
-                             </div>
-                           )}
-                           <span className="text-sm font-medium">{artist.artist}</span>
-                         </a>
-                       ) : (
-                         <div className="flex items-center space-x-2">
-                           {artist.image_url ? (
-                             <Image
-                               src={artist.image_url}
-                               alt={artist.artist}
-                               width={28}
-                               height={28}
-                               className="w-7 h-7 rounded-full object-cover"
-                             />
-                           ) : (
-                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                               <Music className="w-4 h-4 text-muted-foreground" />
-                             </div>
-                           )}
-                           <span className="text-sm font-medium">{artist.artist}</span>
-                         </div>
-                       )}
-                     </Button>
-                  ))}
+                      <div
+                        key={`support-${index}`}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg border bg-muted/30 ${artist.spotify_url ? 'cursor-pointer' : ''}`}
+                        onClick={() => artist.spotify_url && window.open(artist.spotify_url, '_blank')}
+                      >
+                        {artist.image_url ? (
+                          <Image
+                            src={artist.image_url}
+                            alt={artist.artist}
+                            width={24}
+                            height={24}
+                            className="w-6 h-6 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+                            <Music className="w-3 h-3 text-muted-foreground" />
+                          </div>
+                        )}
+                        <span className="text-sm font-medium">{artist.artist}</span>
+                      </div>
+                    ))}
                 </div>
               </div>
             )}
             
             {/* Local Acts */}
             {show.show_artists.filter(artist => artist.position === 'Local').length > 0 && (
-              <div className="space-y-3">
-                <div className="text-sm font-semibold text-foreground border-b border-border pb-1">
-                  Local Support
-                </div>
+              <div className="space-y-2">
+                <div className="text-sm font-semibold text-foreground">Local Support</div>
                 <div className="flex flex-wrap gap-2">
                   {show.show_artists
                     .filter(artist => artist.position === 'Local')
@@ -401,55 +339,27 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                       return 0
                     })
                     .map((artist, index) => (
-                     <Button
-                       key={`local-${index}`}
-                       variant="outline"
-                       size="sm"
-                       asChild={!!artist.spotify_url}
-                       className="h-auto p-3 flex items-center space-x-2 rounded-lg"
-                     >
-                       {artist.spotify_url ? (
-                         <a
-                           href={artist.spotify_url}
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           className="flex items-center space-x-2"
-                         >
-                           {artist.image_url ? (
-                             <Image
-                               src={artist.image_url}
-                               alt={artist.artist}
-                               width={28}
-                               height={28}
-                               className="w-7 h-7 rounded-full object-cover"
-                             />
-                           ) : (
-                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                               <Music className="w-4 h-4 text-muted-foreground" />
-                             </div>
-                           )}
-                           <span className="text-sm font-medium">{artist.artist}</span>
-                         </a>
-                       ) : (
-                         <div className="flex items-center space-x-2">
-                           {artist.image_url ? (
-                             <Image
-                               src={artist.image_url}
-                               alt={artist.artist}
-                               width={28}
-                               height={28}
-                               className="w-7 h-7 rounded-full object-cover"
-                             />
-                           ) : (
-                             <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center">
-                               <Music className="w-4 h-4 text-muted-foreground" />
-                             </div>
-                           )}
-                           <span className="text-sm font-medium">{artist.artist}</span>
-                         </div>
-                       )}
-                     </Button>
-                  ))}
+                      <div
+                        key={`local-${index}`}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg border bg-muted/30 ${artist.spotify_url ? 'cursor-pointer' : ''}`}
+                        onClick={() => artist.spotify_url && window.open(artist.spotify_url, '_blank')}
+                      >
+                        {artist.image_url ? (
+                          <Image
+                            src={artist.image_url}
+                            alt={artist.artist}
+                            width={24}
+                            height={24}
+                            className="w-6 h-6 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-6 h-6 rounded-full bg-muted flex items-center justify-center">
+                            <Music className="w-3 h-3 text-muted-foreground" />
+                          </div>
+                        )}
+                        <span className="text-sm font-medium">{artist.artist}</span>
+                      </div>
+                    ))}
                 </div>
               </div>
             )}
@@ -499,7 +409,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
       </CardContent>
 
       {/* Footer Section */}
-      <CardFooter className="flex-col gap-4 pt-0">
+      <CardFooter className="flex-col gap-4 pt-0 !items-stretch">
         {/* Action Buttons */}
         <div className="flex flex-wrap gap-2 w-full">
           {show.ticket_url && !isPast && (
@@ -556,15 +466,15 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
 
         {/* RSVP Buttons (only for upcoming shows) */}
         {!isPast && userName && (
-          <div className="w-full space-y-3">
-            <div className="text-sm font-medium text-foreground">Your RSVP:</div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <div className="pt-2 border-t border-border">
+            <div className="text-sm text-muted-foreground mb-2">Your RSVP:</div>
+            <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
               <Button
                 size="sm"
                 variant={userStatus === 'going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
                 disabled={loading}
-                className="w-full"
+                className="w-full sm:w-auto"
               >
                 Going
               </Button>
@@ -573,7 +483,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                 variant={userStatus === 'maybe' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'maybe' ? null : 'maybe')}
                 disabled={loading}
-                className="w-full"
+                className="w-full sm:w-auto"
               >
                 Maybe
               </Button>
@@ -582,38 +492,37 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                 variant={userStatus === 'not_going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'not_going' ? null : 'not_going')}
                 disabled={loading}
-                className="w-full"
+                className="w-full sm:w-auto"
               >
                 Not Going
               </Button>
+              {userStatus && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleRSVP(null)}
+                  disabled={loading}
+                  className="w-full sm:w-auto"
+                >
+                  Clear
+                </Button>
+              )}
             </div>
-            {userStatus && (
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => handleRSVP(null)}
-                disabled={loading}
-                className="w-full"
-              >
-                Clear RSVP
-              </Button>
-            )}
           </div>
         )}
 
         {/* Attendance Button (only for past shows) */}
         {isPast && userName && (
-          <div className="w-full space-y-3">
-            <div className="text-sm font-medium text-foreground">Attendance:</div>
-            <div className="flex gap-2">
+          <div className="pt-2 border-t border-border">
+            <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
               <Button
                 size="sm"
                 variant={userStatus === 'going' ? 'default' : 'outline'}
                 onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
                 disabled={loading}
-                className="flex-1"
+                className="w-full sm:w-auto"
               >
-                {userStatus === 'going' ? 'I was there!' : 'Mark as Attended'}
+                {userStatus === 'going' ? 'I was there!' : 'I was there!'}
               </Button>
               {userStatus === 'going' && (
                 <Button
@@ -621,6 +530,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
                   variant="ghost"
                   onClick={() => handleRSVP(null)}
                   disabled={loading}
+                  className="w-full sm:w-auto"
                 >
                   Clear
                 </Button>

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -172,7 +172,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
     : null
 
   return (
-    <Card className="w-full mb-6 overflow-hidden">
+    <Card className="w-full mb-6 overflow-hidden gap-1">
       {/* Header Section */}
       <CardHeader className="pb-4">
         <div className="flex justify-between items-start gap-4">
@@ -222,10 +222,10 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate }
       </CardHeader>
 
       {/* Main Content Section */}
-      <CardContent className="space-y-6">
+      <CardContent className="space-y-4">
         {/* Poster Image */}
         {show.poster_url && (
-          <div className="w-full -mx-6">
+          <div className="w-full flex items-center justify-center bg-muted/30 rounded-lg overflow-hidden">
             <Image
               src={show.poster_url}
               alt={`${show.title} poster`}

--- a/components/ShowCardSkeleton.tsx
+++ b/components/ShowCardSkeleton.tsx
@@ -1,43 +1,65 @@
-import { Card, CardContent } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card'
 
 export function ShowCardSkeleton() {
   return (
-    <Card className="w-full mb-4">
-      <CardContent className="p-4 space-y-3">
-        {/* Header with Date/Time and Actions */}
-        <div className="flex justify-between items-start">
-          <div className="h-6 bg-gray-200 rounded w-32 animate-pulse"></div>
-          <div className="h-8 w-8 bg-gray-200 rounded animate-pulse"></div>
+    <Card className="w-full mb-6 overflow-hidden">
+      {/* Header Section */}
+      <CardHeader className="pb-4">
+        <div className="flex justify-between items-start gap-4">
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="h-6 bg-muted rounded w-3/4 animate-pulse"></div>
+            <div className="h-5 bg-muted rounded w-1/2 animate-pulse"></div>
+            <div className="h-4 bg-muted rounded w-2/3 animate-pulse"></div>
+          </div>
+          <div className="h-8 w-8 bg-muted rounded animate-pulse flex-shrink-0"></div>
+        </div>
+      </CardHeader>
+
+      {/* Main Content Section */}
+      <CardContent className="space-y-6">
+        {/* Poster Image Skeleton */}
+        <div className="w-full -mx-6 h-48 bg-muted animate-pulse"></div>
+
+        {/* Artists Section Skeleton */}
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <div className="h-4 bg-muted rounded w-20 animate-pulse"></div>
+            <div className="flex flex-wrap gap-2">
+              <div className="h-10 bg-muted rounded-lg w-24 animate-pulse"></div>
+              <div className="h-10 bg-muted rounded-lg w-32 animate-pulse"></div>
+            </div>
+          </div>
         </div>
 
-        {/* Title, Venue, and Location */}
-        <div className="space-y-2">
-          <div className="h-6 bg-gray-200 rounded w-3/4 animate-pulse"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse"></div>
-          <div className="h-4 bg-gray-200 rounded w-2/3 animate-pulse"></div>
-        </div>
-
-        {/* Action Buttons */}
-        <div className="flex gap-2">
-          <div className="h-8 bg-gray-200 rounded w-20 animate-pulse"></div>
-        </div>
-
-        {/* RSVPs */}
-        <div className="space-y-2">
-          <div className="h-4 bg-gray-200 rounded w-1/3 animate-pulse"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/4 animate-pulse"></div>
-        </div>
-
-        {/* RSVP Buttons */}
-        <div className="pt-2 border-t">
-          <div className="h-4 bg-gray-200 rounded w-20 mb-2 animate-pulse"></div>
-          <div className="grid grid-cols-2 sm:flex sm:flex-wrap gap-2">
-            <div className="h-8 bg-gray-200 rounded w-full sm:w-20 animate-pulse"></div>
-            <div className="h-8 bg-gray-200 rounded w-full sm:w-20 animate-pulse"></div>
-            <div className="h-8 bg-gray-200 rounded w-full sm:w-24 animate-pulse"></div>
+        {/* RSVPs Section Skeleton */}
+        <div className="space-y-3">
+          <div className="h-4 bg-muted rounded w-16 animate-pulse"></div>
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded w-1/3 animate-pulse"></div>
+            <div className="h-4 bg-muted rounded w-1/4 animate-pulse"></div>
           </div>
         </div>
       </CardContent>
+
+      {/* Footer Section */}
+      <CardFooter className="flex-col gap-4 pt-0">
+        {/* Action Buttons */}
+        <div className="flex flex-wrap gap-2 w-full">
+          <div className="h-8 bg-muted rounded w-24 animate-pulse"></div>
+          <div className="h-8 bg-muted rounded w-20 animate-pulse"></div>
+          <div className="h-8 bg-muted rounded w-24 animate-pulse"></div>
+        </div>
+
+        {/* RSVP Buttons */}
+        <div className="w-full space-y-3">
+          <div className="h-4 bg-muted rounded w-20 animate-pulse"></div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <div className="h-8 bg-muted rounded w-full animate-pulse"></div>
+            <div className="h-8 bg-muted rounded w-full animate-pulse"></div>
+            <div className="h-8 bg-muted rounded w-full animate-pulse"></div>
+          </div>
+        </div>
+      </CardFooter>
     </Card>
   )
 }

--- a/components/ShowCardSkeleton.tsx
+++ b/components/ShowCardSkeleton.tsx
@@ -21,12 +21,13 @@ export function ShowCardSkeleton() {
         <div className="w-full -mx-6 h-48 bg-muted animate-pulse"></div>
 
         {/* Artists Section Skeleton */}
-        <div className="space-y-4">
-          <div className="space-y-3">
-            <div className="h-4 bg-muted rounded w-20 animate-pulse"></div>
-            <div className="flex flex-wrap gap-2">
-              <div className="h-10 bg-muted rounded-lg w-24 animate-pulse"></div>
-              <div className="h-10 bg-muted rounded-lg w-32 animate-pulse"></div>
+        <div className="space-y-2">
+          <div className="space-y-1">
+            <div className="h-3 bg-muted rounded w-16 animate-pulse"></div>
+            <div className="flex flex-wrap gap-1">
+              <div className="h-7 bg-muted rounded w-20 animate-pulse"></div>
+              <div className="h-7 bg-muted rounded w-24 animate-pulse"></div>
+              <div className="h-7 bg-muted rounded w-18 animate-pulse"></div>
             </div>
           </div>
         </div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,6 @@
 export interface ShowArtist {
   artist: string
-  position: 'Headliner' | 'Support'
+  position: 'Headliner' | 'Support' | 'Local'
   image_url?: string
   spotify_id: string
   spotify_url: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "show-tracker",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
-const STATIC_CACHE = 'show-tracker-static-1758860129193';
-const DYNAMIC_CACHE = 'show-tracker-dynamic-1758860129193';
-const VERSION = 'v2025-09-26T04-15-29-9584ad7'; // Update this when you deploy changes
+const STATIC_CACHE = 'show-tracker-static-1758943001766';
+const DYNAMIC_CACHE = 'show-tracker-dynamic-1758943001766';
+const VERSION = 'v2025-09-27T03-16-41-a0b5a3d'; // Update this when you deploy changes
 
 const urlsToCache = [
   '/',


### PR DESCRIPTION
This pull request enhances the recap feature by introducing detailed artist statistics broken down by performance position (Headliner, Support, Local) for both individual users and groups. It adds new backend logic to compute these stats and updates the frontend to display them in a user-friendly tabbed interface.

**Backend: Artist statistics by position**

* Added new fields to the `RecapData` interface to include `personalTopArtistsByPosition` and `groupTopArtistsByPosition`, each containing separate arrays for Headliner, Support, and Local artists. [[1]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R87-R105) [[2]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R157-R175)
* Implemented `calculateUserArtistStatsByPosition` and `calculateGroupArtistStatsByPosition` helper functions to compute top artists by position for users and groups, respectively. These functions aggregate, sort, and limit the results for each position.
* Updated the main API handler to call these new functions and include their results in the API response. [[1]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R905-R909) [[2]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R924-R926) [[3]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R1204-R1208) [[4]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R1219-R1221) [[5]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R1267) [[6]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8L1067-R1287)

**Backend: Improved artist sorting**

* Enhanced the sorting logic in both user and group artist stats to prioritize headliners when artist counts are equal, ensuring more relevant artists are highlighted. [[1]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R369) [[2]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R379-R416) [[3]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R442) [[4]](diffhunk://#diff-a9b35574e6960f31a78fb9d32f3b2e74b4a1a21f1531eade6c0e0e41e3a2bce8R453-R490)

**Frontend: Tabbed artist stats display**

* Added a tabbed interface to the recap page, allowing users to view their top artists overall or filtered by Headliner, Support, or Local positions. Each tab displays the corresponding list of artists with their images and show counts. [[1]](diffhunk://#diff-5ea9af6728d4362c09efb7b149e6734dfd3f16b16b68252d9701c79a46e10118R9) [[2]](diffhunk://#diff-5ea9af6728d4362c09efb7b149e6734dfd3f16b16b68252d9701c79a46e10118L503-R522) [[3]](diffhunk://#diff-5ea9af6728d4362c09efb7b149e6734dfd3f16b16b68252d9701c79a46e10118R554-R672)

These changes provide users with a more granular view of their concert attendance, making it easy to see which artists they've seen most often in different roles.