### PR TITLE
Enhance ShowCard with search and compact view features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Show Tracker will be documented in this file.
 
 ---
 
+## [1.10.3] - 2026-06-05
+
+### Added
+- **Show search bar** — Instant search below the filter bar on both Upcoming and Past tabs; matches against show title, artist names, city, and venue. Typing a partial term (e.g. "boston") surfaces all shows containing that string anywhere in those fields. Includes a clear (×) button.
+- **Compact / expanded view toggle** — Button next to the search bar switches all show cards between the full expanded layout and a compact single-line layout. Preference is persisted in a cookie for future visits (expanded by default).
+- **Compact card design** — Condensed card shows a 56×56 poster thumbnail, title, date/time, venue · city, and artist names on one row. Upcoming shows display inline Going / Maybe / Not Going RSVP buttons; past shows show an "I was there!" attendance toggle — no need to open the full card to RSVP.
+- **Inline card expansion** — Clicking the poster or info text on a compact card expands it to the full card view inline; a "Collapse" bar at the top collapses it back. Switching the global toggle back to compact mode resets all inline expansions.
+
+---
+
 ## [1.10.2] - 2026-04-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A modern Progressive Web App for groups to track concerts and manage RSVPs**
 
-[![Version](https://img.shields.io/badge/version-1.10.2-blue)](https://github.com/emonhoque/show-tracker/releases)
+[![Version](https://img.shields.io/badge/version-1.10.3-blue)](https://github.com/emonhoque/show-tracker/releases)
 [![Next.js](https://img.shields.io/badge/Next.js-16.1.0-black)](https://nextjs.org)
 [![React](https://img.shields.io/badge/React-19.2.3-blue)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -621,7 +621,7 @@ export default function Home() {
                 )
               }
               return (
-                <div className={isCompact ? 'grid grid-cols-1 sm:grid-cols-2 gap-2' : 'space-y-4'}>
+                <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
                   {displayShows.map((show) => (
                     <ShowCard
                       key={show.id}
@@ -694,7 +694,7 @@ export default function Home() {
                       {`No shows found for "${pastSearchQuery}"`}
                     </p>
                   ) : (
-                    <div className={isCompact ? 'grid grid-cols-1 sm:grid-cols-2 gap-2' : 'space-y-4'}>
+                    <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
                       {displayShows.map((show) => (
                         <ShowCard
                           key={show.id}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { Search, X, Minimize2, Maximize2 } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { PasswordGate } from '@/components/PasswordGate'
 import { ShowCard } from '@/components/ShowCard'
@@ -49,6 +52,10 @@ export default function Home() {
   const [isOffline, setIsOffline] = useState(false)
   const [cacheVersion, setCacheVersion] = useState(0)
 
+  const [upcomingSearchQuery, setUpcomingSearchQuery] = useState('')
+  const [pastSearchQuery, setPastSearchQuery] = useState('')
+  const [isCompact, setIsCompact] = useState(false)
+
   // Merch modal state (Add Merch from Show)
   const [showMerchModal, setShowMerchModal] = useState(false)
   const [merchShowId, setMerchShowId] = useState<string | null>(null)
@@ -64,7 +71,8 @@ export default function Home() {
       setUserName(storedName)
       setAuthenticated(true)
     }
-
+    const compactMatch = document.cookie.match(/(?:^|;\s*)showCardCompact=([^;]+)/)
+    if (compactMatch) setIsCompact(compactMatch[1] === 'true')
   }, [])
 
   const { showToast } = useToast()
@@ -324,6 +332,23 @@ export default function Home() {
     setSelectedPeopleFilters(new Set(['all']))
   }
 
+  const handleToggleCompact = () => {
+    const next = !isCompact
+    setIsCompact(next)
+    document.cookie = `showCardCompact=${next}; path=/; max-age=${365 * 24 * 3600}`
+  }
+
+  const filterBySearch = (shows: Show[], query: string): Show[] => {
+    if (!query.trim()) return shows
+    const q = query.toLowerCase()
+    return shows.filter(show =>
+      show.title.toLowerCase().includes(q) ||
+      show.city.toLowerCase().includes(q) ||
+      show.venue.toLowerCase().includes(q) ||
+      show.show_artists?.some(a => a.artist.toLowerCase().includes(q))
+    )
+  }
+
   const handleShowAdded = async () => {
     // Show success toast
     showToast({
@@ -523,9 +548,9 @@ export default function Home() {
             <TabsTrigger value="releases">Music</TabsTrigger>
           </TabsList>
           
-          <TabsContent value="upcoming" className="space-y-6">
+          <TabsContent value="upcoming" className="space-y-4">
             <h2 className="sr-only">Upcoming Shows</h2>
-            
+
             {/* RSVP Filter */}
             {loading ? (
               <RSVPFilterSkeleton />
@@ -540,38 +565,118 @@ export default function Home() {
                 onClearAllFilters={handleClearAllFilters}
               />
             )}
-            
+
+            {/* Search bar + compact toggle */}
+            {!loading && (
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                  <Input
+                    type="text"
+                    placeholder="Search by artist, title, city or venue..."
+                    value={upcomingSearchQuery}
+                    onChange={e => setUpcomingSearchQuery(e.target.value)}
+                    className="pl-9 pr-9"
+                  />
+                  {upcomingSearchQuery && (
+                    <button
+                      onClick={() => setUpcomingSearchQuery('')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear search"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleToggleCompact}
+                  title={isCompact ? 'Switch to expanded view' : 'Switch to compact view'}
+                  aria-label={isCompact ? 'Switch to expanded view' : 'Switch to compact view'}
+                >
+                  {isCompact ? <Maximize2 className="w-4 h-4" /> : <Minimize2 className="w-4 h-4" />}
+                </Button>
+              </div>
+            )}
+
             {loading ? (
               <>
                 <ShowCardSkeleton />
                 <ShowCardSkeleton />
                 <ShowCardSkeleton />
               </>
-            ) : filteredUpcomingShows.length === 0 ? (
-              <p className="text-center text-muted-foreground py-8">
-                {upcomingShows.length === 0 
-                  ? 'No upcoming shows' 
-                  : 'No shows match the selected filters'
-                }
-              </p>
-            ) : (
-              filteredUpcomingShows.map((show) => (
-                <ShowCard 
-                  key={show.id} 
-                  show={show} 
-                  isPast={false} 
-                  rsvps={rsvpsData[show.id] || { going: [], maybe: [], not_going: [] }}
-                  onEdit={handleEditShow}
-                  onDelete={handleDeleteShow}
-                  onRSVPUpdate={() => updateRSVPs(show.id)}
-                  onDuplicate={handleDuplicateShow}
-                />
-              ))
-            )}
+            ) : (() => {
+              const displayShows = filterBySearch(filteredUpcomingShows, upcomingSearchQuery)
+              if (displayShows.length === 0) {
+                return (
+                  <p className="text-center text-muted-foreground py-8">
+                    {upcomingShows.length === 0
+                      ? 'No upcoming shows'
+                      : upcomingSearchQuery.trim()
+                      ? `No shows found for "${upcomingSearchQuery}"`
+                      : 'No shows match the selected filters'
+                    }
+                  </p>
+                )
+              }
+              return (
+                <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
+                  {displayShows.map((show) => (
+                    <ShowCard
+                      key={show.id}
+                      show={show}
+                      isPast={false}
+                      rsvps={rsvpsData[show.id] || { going: [], maybe: [], not_going: [] }}
+                      onEdit={handleEditShow}
+                      onDelete={handleDeleteShow}
+                      onRSVPUpdate={() => updateRSVPs(show.id)}
+                      onDuplicate={handleDuplicateShow}
+                      compact={isCompact}
+                    />
+                  ))}
+                </div>
+              )
+            })()}
           </TabsContent>
           
           <TabsContent value="past" className="space-y-4">
             <h2 className="sr-only">Past Shows</h2>
+
+            {/* Search bar + compact toggle */}
+            {!loading && (
+              <div className="flex gap-2">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                  <Input
+                    type="text"
+                    placeholder="Search by artist, title, city or venue..."
+                    value={pastSearchQuery}
+                    onChange={e => setPastSearchQuery(e.target.value)}
+                    className="pl-9 pr-9"
+                  />
+                  {pastSearchQuery && (
+                    <button
+                      onClick={() => setPastSearchQuery('')}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label="Clear search"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={handleToggleCompact}
+                  title={isCompact ? 'Switch to expanded view' : 'Switch to compact view'}
+                  aria-label={isCompact ? 'Switch to expanded view' : 'Switch to compact view'}
+                >
+                  {isCompact ? <Maximize2 className="w-4 h-4" /> : <Minimize2 className="w-4 h-4" />}
+                </Button>
+              </div>
+            )}
+
             {loading ? (
               <>
                 <ShowCardSkeleton />
@@ -580,36 +685,48 @@ export default function Home() {
               </>
             ) : pastShows.length === 0 ? (
               <p className="text-center text-muted-foreground py-8">No past shows</p>
-            ) : (
-              <>
-                {pastShows.map((show) => (
-                  <ShowCard 
-                    key={show.id} 
-                    show={show} 
-                    isPast={true} 
-                    rsvps={rsvpsData[show.id] || { going: [], maybe: [], not_going: [] }}
-                    onEdit={handleEditShow}
-                    onDelete={handleDeleteShow}
-                    onRSVPUpdate={() => updateRSVPs(show.id)}
-                    onDuplicate={handleDuplicateShow}
-                    onAddMerch={handleAddMerchFromShow}
-                  />
-                ))}
-                
-                {/* Infinite scroll loading indicator */}
-                {loadingMore && (
-                  <div className="flex justify-center py-4">
-                    <div className="flex items-center gap-2 text-muted-foreground">
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-muted-foreground"></div>
-                      <span>Loading more shows...</span>
+            ) : (() => {
+              const displayShows = filterBySearch(pastShows, pastSearchQuery)
+              return (
+                <>
+                  {displayShows.length === 0 ? (
+                    <p className="text-center text-muted-foreground py-8">
+                      {`No shows found for "${pastSearchQuery}"`}
+                    </p>
+                  ) : (
+                    <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
+                      {displayShows.map((show) => (
+                        <ShowCard
+                          key={show.id}
+                          show={show}
+                          isPast={true}
+                          rsvps={rsvpsData[show.id] || { going: [], maybe: [], not_going: [] }}
+                          onEdit={handleEditShow}
+                          onDelete={handleDeleteShow}
+                          onRSVPUpdate={() => updateRSVPs(show.id)}
+                          onDuplicate={handleDuplicateShow}
+                          onAddMerch={handleAddMerchFromShow}
+                          compact={isCompact}
+                        />
+                      ))}
                     </div>
-                  </div>
-                )}
-                
-                {/* Infinite scroll sentinel */}
-                <div ref={sentinelRef} className="h-4" />
-              </>
-            )}
+                  )}
+
+                  {/* Infinite scroll loading indicator */}
+                  {loadingMore && (
+                    <div className="flex justify-center py-4">
+                      <div className="flex items-center gap-2 text-muted-foreground">
+                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-muted-foreground"></div>
+                        <span>Loading more shows...</span>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Infinite scroll sentinel */}
+                  <div ref={sentinelRef} className="h-4" />
+                </>
+              )
+            })()}
           </TabsContent>
           
           <TabsContent value="releases" className="space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -621,7 +621,7 @@ export default function Home() {
                 )
               }
               return (
-                <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
+                <div className={isCompact ? 'grid grid-cols-1 sm:grid-cols-2 gap-2' : 'space-y-4'}>
                   {displayShows.map((show) => (
                     <ShowCard
                       key={show.id}
@@ -694,7 +694,7 @@ export default function Home() {
                       {`No shows found for "${pastSearchQuery}"`}
                     </p>
                   ) : (
-                    <div className={isCompact ? 'space-y-1' : 'space-y-4'}>
+                    <div className={isCompact ? 'grid grid-cols-1 sm:grid-cols-2 gap-2' : 'space-y-4'}>
                       {displayShows.map((show) => (
                         <ShowCard
                           key={show.id}

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -431,7 +431,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
   return (
     <Card
       id={`show-${show.id}`}
-      className={`w-full overflow-hidden gap-1 transition-all duration-500 ${compact && inlineExpanded ? 'sm:col-span-2' : 'mb-6'} ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
+      className={`w-full mb-6 overflow-hidden gap-1 transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
     >
       {compact && inlineExpanded && (
         <button

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -34,9 +34,10 @@ interface ShowCardProps {
   onRSVPUpdate?: () => void
   onDuplicate?: (show: Show) => void
   onAddMerch?: (show: Show) => void
+  compact?: boolean
 }
 
-export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, onDuplicate, onAddMerch }: ShowCardProps) {
+export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, onDuplicate, onAddMerch, compact }: ShowCardProps) {
   const [loading, setLoading] = useState(false)
   const [userName, setUserName] = useState<string | null>(null)
   const [imageModalOpen, setImageModalOpen] = useState(false)
@@ -272,8 +273,104 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
       : null
     : null
 
+  if (compact) {
+    return (
+      <Card
+        id={`show-${show.id}`}
+        className={`w-full overflow-hidden transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
+      >
+        <div className="flex items-center gap-3 p-3">
+          {show.poster_url ? (
+            <Image
+              src={show.poster_url}
+              alt={`${show.title} poster`}
+              width={56}
+              height={56}
+              className="w-14 h-14 rounded-lg object-cover flex-shrink-0"
+            />
+          ) : (
+            <div className="w-14 h-14 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
+              <Music className="w-6 h-6 text-muted-foreground" />
+            </div>
+          )}
+
+          <div className="flex-1 min-w-0">
+            <div className="font-semibold text-sm truncate">{show.title}</div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              {formatUserTime(show.date_time, show.time_local)}
+              {!isPast && (
+                <span className="ml-1 text-muted-foreground/70">({formatDaysUntilShow(show.date_time)})</span>
+              )}
+            </div>
+            <div className="text-xs text-muted-foreground">{show.venue} · {show.city}</div>
+            {show.show_artists && show.show_artists.length > 0 && (
+              <div className="text-xs text-muted-foreground/70 truncate">
+                {show.show_artists.map(a => a.artist).join(' · ')}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {userStatus && (
+              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                userStatus === 'going'
+                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                  : userStatus === 'maybe'
+                  ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+              }`}>
+                {userStatus === 'going' ? 'Going' : userStatus === 'maybe' ? 'Maybe' : 'Not Going'}
+              </span>
+            )}
+            <DropdownMenu.DropdownMenu>
+              <DropdownMenu.DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  aria-label={`More options for ${show.title}`}
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenu.DropdownMenuTrigger>
+              <DropdownMenu.DropdownMenuContent align="end" className="w-48">
+                {onEdit && (
+                  <DropdownMenu.DropdownMenuItem onClick={() => onEdit(show)}>
+                    <Edit className="mr-2 h-4 w-4" />
+                    Edit
+                  </DropdownMenu.DropdownMenuItem>
+                )}
+                {onDuplicate && userName === 'emon hoque' && !isPast && (
+                  <DropdownMenu.DropdownMenuItem onClick={handleDuplicate} disabled={loading}>
+                    <CopyIcon className="mr-2 h-4 w-4" />
+                    Duplicate
+                  </DropdownMenu.DropdownMenuItem>
+                )}
+                {onDelete && (!isPast || userName === 'emon hoque') && (
+                  <DropdownMenu.DropdownMenuItem
+                    onClick={() => onDelete(show.id)}
+                    className="text-red-600 focus:text-red-600"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete
+                  </DropdownMenu.DropdownMenuItem>
+                )}
+                {isPast && onAddMerch && (
+                  <DropdownMenu.DropdownMenuItem onClick={() => onAddMerch(show)}>
+                    <ShoppingBag className="mr-2 h-4 w-4" />
+                    Add Merch
+                  </DropdownMenu.DropdownMenuItem>
+                )}
+              </DropdownMenu.DropdownMenuContent>
+            </DropdownMenu.DropdownMenu>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
   return (
-    <Card 
+    <Card
       id={`show-${show.id}`}
       className={`w-full mb-6 overflow-hidden gap-1 transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
     >

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -280,9 +280,6 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
     : null
 
   if (compact && !inlineExpanded) {
-    const hasTickets = !isPast && show.ticket_url
-    const hasPhotos = isPast && show.google_photos_url
-
     return (
       <Card
         id={`show-${show.id}`}
@@ -424,40 +421,6 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
                 </Button>
               )}
 
-              {/* Divider before extra actions */}
-              {(hasTickets || hasPhotos) && (
-                <div className="w-px h-4 bg-border mx-0.5" />
-              )}
-
-              {/* Tickets (upcoming only) */}
-              {hasTickets && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  asChild
-                  className="h-7 text-xs px-2.5"
-                >
-                  <a href={show.ticket_url!} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="w-3 h-3 mr-1" />
-                    Tickets
-                  </a>
-                </Button>
-              )}
-
-              {/* Photos (past only) */}
-              {hasPhotos && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  asChild
-                  className="h-7 text-xs px-2.5"
-                >
-                  <a href={show.google_photos_url!} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="w-3 h-3 mr-1" />
-                    Photos
-                  </a>
-                </Button>
-              )}
             </div>
           </div>
         </div>
@@ -468,7 +431,7 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
   return (
     <Card
       id={`show-${show.id}`}
-      className={`w-full mb-6 overflow-hidden gap-1 transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
+      className={`w-full overflow-hidden gap-1 transition-all duration-500 ${compact && inlineExpanded ? 'sm:col-span-2' : 'mb-6'} ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
     >
       {compact && inlineExpanded && (
         <button

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter }
 import { Show, RSVPSummary } from '@/lib/types'
 import { formatUserTime, formatDaysUntilShow } from '@/lib/time'
 import { formatNameForDisplay } from '@/lib/validation'
-import { ExternalLink, MoreVertical, Edit, Trash2, Copy, Music, CopyIcon, Link2, ShoppingBag } from 'lucide-react'
+import { ExternalLink, MoreVertical, Edit, Trash2, Copy, Music, CopyIcon, Link2, ShoppingBag, ChevronUp } from 'lucide-react'
 import { ImageModal } from '@/components/ImageModal'
 import { ExportToCalendar } from '@/components/ExportToCalendar'
 import { ShareShowImage } from '@/components/ShareShowImage'
@@ -43,7 +43,13 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
   const [imageModalOpen, setImageModalOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)
   const [isHighlighted, setIsHighlighted] = useState(false)
+  const [inlineExpanded, setInlineExpanded] = useState(false)
   const { showToast } = useToast()
+
+  // Reset inline expansion when leaving compact mode so cards start collapsed next time
+  useEffect(() => {
+    if (!compact) setInlineExpanded(false)
+  }, [compact])
 
   // Get userName from localStorage on client side
   useEffect(() => {
@@ -273,13 +279,19 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
       : null
     : null
 
-  if (compact) {
+  if (compact && !inlineExpanded) {
     return (
       <Card
         id={`show-${show.id}`}
         className={`w-full overflow-hidden transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
       >
-        <div className="flex items-center gap-3 p-3">
+        <div
+          className="flex items-center gap-3 p-3 cursor-pointer hover:bg-muted/30 transition-colors"
+          onClick={() => setInlineExpanded(true)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setInlineExpanded(true) }}
+        >
           {show.poster_url ? (
             <Image
               src={show.poster_url}
@@ -310,8 +322,8 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
             )}
           </div>
 
-          <div className="flex items-center gap-1.5 flex-shrink-0">
-            {userStatus && (
+          <div className="flex items-center gap-1.5 flex-shrink-0" onClick={e => e.stopPropagation()}>
+            {!isPast && userStatus && (
               <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
                 userStatus === 'going'
                   ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
@@ -320,6 +332,11 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
                   : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
               }`}>
                 {userStatus === 'going' ? 'Going' : userStatus === 'maybe' ? 'Maybe' : 'Not Going'}
+              </span>
+            )}
+            {isPast && userStatus === 'going' && (
+              <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                Attended
               </span>
             )}
             <DropdownMenu.DropdownMenu>
@@ -374,6 +391,15 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
       id={`show-${show.id}`}
       className={`w-full mb-6 overflow-hidden gap-1 transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
     >
+      {compact && inlineExpanded && (
+        <button
+          onClick={() => setInlineExpanded(false)}
+          className="w-full flex items-center justify-center gap-1 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors border-b border-border"
+        >
+          <ChevronUp className="w-3 h-3" />
+          Collapse
+        </button>
+      )}
       {/* Header Section */}
       <CardHeader className="pb-4">
         <div className="flex justify-between items-start gap-4">

--- a/components/ShowCard.tsx
+++ b/components/ShowCard.tsx
@@ -280,106 +280,185 @@ export function ShowCard({ show, isPast, rsvps, onEdit, onDelete, onRSVPUpdate, 
     : null
 
   if (compact && !inlineExpanded) {
+    const hasTickets = !isPast && show.ticket_url
+    const hasPhotos = isPast && show.google_photos_url
+
     return (
       <Card
         id={`show-${show.id}`}
         className={`w-full overflow-hidden transition-all duration-500 ${isHighlighted ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}
       >
-        <div
-          className="flex items-center gap-3 p-3 cursor-pointer hover:bg-muted/30 transition-colors"
-          onClick={() => setInlineExpanded(true)}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setInlineExpanded(true) }}
-        >
-          {show.poster_url ? (
-            <Image
-              src={show.poster_url}
-              alt={`${show.title} poster`}
-              width={56}
-              height={56}
-              className="w-14 h-14 rounded-lg object-cover flex-shrink-0"
-            />
-          ) : (
-            <div className="w-14 h-14 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">
-              <Music className="w-6 h-6 text-muted-foreground" />
-            </div>
-          )}
-
-          <div className="flex-1 min-w-0">
-            <div className="font-semibold text-sm truncate">{show.title}</div>
-            <div className="text-xs text-muted-foreground mt-0.5">
-              {formatUserTime(show.date_time, show.time_local)}
-              {!isPast && (
-                <span className="ml-1 text-muted-foreground/70">({formatDaysUntilShow(show.date_time)})</span>
-              )}
-            </div>
-            <div className="text-xs text-muted-foreground">{show.venue} · {show.city}</div>
-            {show.show_artists && show.show_artists.length > 0 && (
-              <div className="text-xs text-muted-foreground/70 truncate">
-                {show.show_artists.map(a => a.artist).join(' · ')}
+        <div className="flex items-start gap-3 p-3">
+          {/* Poster — clicking it expands the card */}
+          <div
+            className="flex-shrink-0 cursor-pointer"
+            onClick={() => setInlineExpanded(true)}
+          >
+            {show.poster_url ? (
+              <Image
+                src={show.poster_url}
+                alt={`${show.title} poster`}
+                width={56}
+                height={56}
+                className="w-14 h-14 rounded-lg object-cover hover:opacity-80 transition-opacity"
+              />
+            ) : (
+              <div className="w-14 h-14 rounded-lg bg-muted flex items-center justify-center">
+                <Music className="w-6 h-6 text-muted-foreground" />
               </div>
             )}
           </div>
 
-          <div className="flex items-center gap-1.5 flex-shrink-0" onClick={e => e.stopPropagation()}>
-            {!isPast && userStatus && (
-              <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                userStatus === 'going'
-                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                  : userStatus === 'maybe'
-                  ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-                  : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-              }`}>
-                {userStatus === 'going' ? 'Going' : userStatus === 'maybe' ? 'Maybe' : 'Not Going'}
-              </span>
-            )}
-            {isPast && userStatus === 'going' && (
-              <span className="text-xs px-2 py-0.5 rounded-full font-medium bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                Attended
-              </span>
-            )}
-            <DropdownMenu.DropdownMenu>
-              <DropdownMenu.DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-8 p-0"
-                  aria-label={`More options for ${show.title}`}
-                >
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenu.DropdownMenuTrigger>
-              <DropdownMenu.DropdownMenuContent align="end" className="w-48">
-                {onEdit && (
-                  <DropdownMenu.DropdownMenuItem onClick={() => onEdit(show)}>
-                    <Edit className="mr-2 h-4 w-4" />
-                    Edit
-                  </DropdownMenu.DropdownMenuItem>
+          {/* Right side: info + actions */}
+          <div className="flex-1 min-w-0">
+            {/* Info row */}
+            <div className="flex items-start gap-1">
+              <div
+                className="flex-1 min-w-0 cursor-pointer"
+                onClick={() => setInlineExpanded(true)}
+              >
+                <div className="font-semibold text-sm truncate">{show.title}</div>
+                <div className="text-xs text-muted-foreground mt-0.5">
+                  {formatUserTime(show.date_time, show.time_local)}
+                  {!isPast && (
+                    <span className="ml-1 text-muted-foreground/70">({formatDaysUntilShow(show.date_time)})</span>
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground">{show.venue} · {show.city}</div>
+                {show.show_artists && show.show_artists.length > 0 && (
+                  <div className="text-xs text-muted-foreground/70 truncate">
+                    {show.show_artists.map(a => a.artist).join(' · ')}
+                  </div>
                 )}
-                {onDuplicate && userName === 'emon hoque' && !isPast && (
-                  <DropdownMenu.DropdownMenuItem onClick={handleDuplicate} disabled={loading}>
-                    <CopyIcon className="mr-2 h-4 w-4" />
-                    Duplicate
-                  </DropdownMenu.DropdownMenuItem>
-                )}
-                {onDelete && (!isPast || userName === 'emon hoque') && (
-                  <DropdownMenu.DropdownMenuItem
-                    onClick={() => onDelete(show.id)}
-                    className="text-red-600 focus:text-red-600"
+              </div>
+
+              {/* Menu */}
+              <DropdownMenu.DropdownMenu>
+                <DropdownMenu.DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0 flex-shrink-0"
+                    aria-label={`More options for ${show.title}`}
                   >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    Delete
-                  </DropdownMenu.DropdownMenuItem>
-                )}
-                {isPast && onAddMerch && (
-                  <DropdownMenu.DropdownMenuItem onClick={() => onAddMerch(show)}>
-                    <ShoppingBag className="mr-2 h-4 w-4" />
-                    Add Merch
-                  </DropdownMenu.DropdownMenuItem>
-                )}
-              </DropdownMenu.DropdownMenuContent>
-            </DropdownMenu.DropdownMenu>
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenu.DropdownMenuTrigger>
+                <DropdownMenu.DropdownMenuContent align="end" className="w-48">
+                  {onEdit && (
+                    <DropdownMenu.DropdownMenuItem onClick={() => onEdit(show)}>
+                      <Edit className="mr-2 h-4 w-4" />
+                      Edit
+                    </DropdownMenu.DropdownMenuItem>
+                  )}
+                  {onDuplicate && userName === 'emon hoque' && !isPast && (
+                    <DropdownMenu.DropdownMenuItem onClick={handleDuplicate} disabled={loading}>
+                      <CopyIcon className="mr-2 h-4 w-4" />
+                      Duplicate
+                    </DropdownMenu.DropdownMenuItem>
+                  )}
+                  {onDelete && (!isPast || userName === 'emon hoque') && (
+                    <DropdownMenu.DropdownMenuItem
+                      onClick={() => onDelete(show.id)}
+                      className="text-red-600 focus:text-red-600"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </DropdownMenu.DropdownMenuItem>
+                  )}
+                  {isPast && onAddMerch && (
+                    <DropdownMenu.DropdownMenuItem onClick={() => onAddMerch(show)}>
+                      <ShoppingBag className="mr-2 h-4 w-4" />
+                      Add Merch
+                    </DropdownMenu.DropdownMenuItem>
+                  )}
+                </DropdownMenu.DropdownMenuContent>
+              </DropdownMenu.DropdownMenu>
+            </div>
+
+            {/* Action buttons row */}
+            <div className="flex flex-wrap items-center gap-1 mt-2">
+              {/* Upcoming RSVP */}
+              {!isPast && userName && (
+                <>
+                  <Button
+                    size="sm"
+                    variant={userStatus === 'going' ? 'default' : 'outline'}
+                    onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
+                    disabled={loading}
+                    className="h-7 text-xs px-2.5"
+                  >
+                    Going
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant={userStatus === 'maybe' ? 'default' : 'outline'}
+                    onClick={() => handleRSVP(userStatus === 'maybe' ? null : 'maybe')}
+                    disabled={loading}
+                    className="h-7 text-xs px-2.5"
+                  >
+                    Maybe
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant={userStatus === 'not_going' ? 'default' : 'outline'}
+                    onClick={() => handleRSVP(userStatus === 'not_going' ? null : 'not_going')}
+                    disabled={loading}
+                    className="h-7 text-xs px-2.5"
+                  >
+                    Not Going
+                  </Button>
+                </>
+              )}
+
+              {/* Past: attendance */}
+              {isPast && userName && (
+                <Button
+                  size="sm"
+                  variant={userStatus === 'going' ? 'default' : 'outline'}
+                  onClick={() => handleRSVP(userStatus === 'going' ? null : 'going')}
+                  disabled={loading}
+                  className="h-7 text-xs px-2.5"
+                >
+                  {userStatus === 'going' ? 'Was there ✓' : 'I was there!'}
+                </Button>
+              )}
+
+              {/* Divider before extra actions */}
+              {(hasTickets || hasPhotos) && (
+                <div className="w-px h-4 bg-border mx-0.5" />
+              )}
+
+              {/* Tickets (upcoming only) */}
+              {hasTickets && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  asChild
+                  className="h-7 text-xs px-2.5"
+                >
+                  <a href={show.ticket_url!} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="w-3 h-3 mr-1" />
+                    Tickets
+                  </a>
+                </Button>
+              )}
+
+              {/* Photos (past only) */}
+              {hasPhotos && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  asChild
+                  className="h-7 text-xs px-2.5"
+                >
+                  <a href={show.google_photos_url!} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="w-3 h-3 mr-1" />
+                    Photos
+                  </a>
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </Card>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "show-tracker",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request introduces several major UI improvements to the Show Tracker app, focusing on enhanced usability for browsing and managing shows. The main changes are the addition of a search bar for instant filtering, a compact/expanded card view toggle (with cookie-based persistence), and a new compact card design supporting inline expansion. These features are implemented for both Upcoming and Past show tabs, significantly improving navigation and RSVP workflows.

**New features and UI improvements:**

* Added a search bar below the filter bar on both Upcoming and Past tabs, allowing instant filtering by show title, artist, city, or venue, with a clear (×) button. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R569-R625) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R635-R679) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L583-R698)
* Introduced a compact/expanded view toggle button next to the search bar; the user's preference is saved in a cookie for future visits. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R55-R58) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L67-R75) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R335-R351) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R569-R625)
* Implemented a compact show card design: single-row layout with poster, title, date/time, venue, city, and artists, plus inline RSVP buttons for upcoming shows and an attendance toggle for past shows. [[1]](diffhunk://#diff-2638a0b3f61ae4e6240cd962c6108e64c7fc4bae614d9b4455ea793716cacbecR37-R53) [[2]](diffhunk://#diff-2638a0b3f61ae4e6240cd962c6108e64c7fc4bae614d9b4455ea793716cacbecR282-R444)
* Enabled inline card expansion: clicking the poster or info expands the card to full view inline, with a "Collapse" bar to revert; switching back to compact mode resets all inline expansions.

**Documentation and versioning:**

* Updated `CHANGELOG.md`, `README.md`, and `package.json` to reflect version 1.10.3 and document the new features. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)